### PR TITLE
Feature/team gg

### DIFF
--- a/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/end_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/end_match.mcfunction
@@ -8,7 +8,7 @@ tellraw @a {"translate":">>> %s","color":"white","with":[{"text":"The match is o
 playsound minecraft:event.raid.horn master @a 217 100 195 999999 0.75
 
 # Make all players spectators!
-execute at @a run function moesh:player/spectate
+execute as @a run function moesh:player/spectate
 
 # The match has ended, let's updated the SessionID so players are properly handled
 execute store result score SessionID gameVariable run time query gametime
@@ -22,7 +22,7 @@ scoreboard players reset @a gg
 scoreboard players reset @a reset
 scoreboard players enable @a reset
 
-# Remove forfiet tag
+# Remove forfeit tag
 tag @a remove VotedForfeit
 
 #---------------------------------------------------------------------------------------------------

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/end_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/end_match.mcfunction
@@ -22,6 +22,9 @@ scoreboard players reset @a gg
 scoreboard players reset @a reset
 scoreboard players enable @a reset
 
+# Remove forfiet tag
+tag @a remove VotedForfeit
+
 #---------------------------------------------------------------------------------------------------
 # Purpose: Update game state
 #---------------------------------------------------------------------------------------------------

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/handler.mcfunction
@@ -25,6 +25,20 @@ execute if score GameState gameVariable matches 0 if score StartingMatch gameVar
 # Prevent players from leaving the play area
 # TODO: execute as @a at @s unless entity @s[gamemode=spectator] if score GameState gameVariable matches 1 run function moesh:game_state/out_of_bounds
 
+# Count the players and check if someone left. If they did recheck forfeit state
+#
+# The forfeit check normally only happens when someone triggers the gg trigger
+# Meaning that if everyone but one person has voted for forfeit and that player then leaves the game won't end
+# even though everyone online has voted for forfeit
+# We fix this problem by checking if a player leaves and then checks the forfeit state
+execute if score GameState gameVariable matches 1 store result score #tempVar gameVariable run execute if entity @a
+execute if score GameState gameVariable matches 1 run scoreboard players operation Players gameVariable -= #tempVar gameVariable
+execute if score GameState gameVariable matches 1 if score Players gameVariable matches 1.. run function moesh:game_state/trigger_gg
+execute if score GameState gameVariable matches 1 run scoreboard players operation Players gameVariable = #tempVar gameVariable
+
+# Reset our temp variable
+scoreboard players reset #tempVar gameVariable
+
 # This next line is essentially protection of players against themselves. They can use
 # Let players run a GG command to end a game early
 # /trigger set gg 0, therefore disabling the gg trigger for themselves.

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/trigger_gg.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/trigger_gg.mcfunction
@@ -4,7 +4,7 @@
 # Purpose: Let a player quit the game early.
 #---------------------------------------------------------------------------------------------------
 
-# Mark players who has run the gg trigger
+# Mark players who have run the gg trigger
 tag @a[team=blue,gamemode=!spectator,scores={gg=1..}] add ForfeitTriggered
 tag @a[team=red,gamemode=!spectator,scores={gg=1..}] add ForfeitTriggered
 scoreboard players set @a[scores={gg=1..}] gg 0
@@ -22,17 +22,19 @@ tag @a[tag=ForfeitTriggered,tag=StopForfeit] remove StopForfeit
 # Count the amount of players on blue team
 # And count the players who has voted for forfeit
 execute store result score #tempPlayerCount gameVariable run execute if entity @a[team=blue]
+scoreboard players operation #tempPlayerCount gameVariable *= PercentPlayersToForfeit mapRules
+scoreboard players operation #tempPlayerCount gameVariable /= 100 CONST
 execute store result score #tempForfeitCount gameVariable run execute if entity @a[team=blue,tag=VotedForfeit]
 
 # Tell players on the team someone wants to forfeit
-execute if entity @a[team=blue,tag=ForfeitTriggered,tag=VotedForfeit] unless score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a[team=blue] {"translate":">>> %s has voted to forfeit the game. %s out of %s players have voted to forfeit. Use [%s] to vote.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}},{"text":"/trigger gg","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger gg"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}
+execute if entity @a[team=blue,tag=ForfeitTriggered,tag=VotedForfeit] if score #tempPlayerCount gameVariable > #tempForfeitCount gameVariable run tellraw @a[team=blue] {"translate":">>> %s has voted to forfeit the game. %s out of the needed %s players have voted to forfeit. Use [%s] to vote.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}},{"text":"/trigger gg","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger gg"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}
 execute if entity @a[team=blue,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 0 run tellraw @a[team=blue] {"translate":">>> %s has retracted their forfeit vote. Voting stopped.","with":[{"selector":"@s"}]}
-execute if entity @a[team=blue,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 1.. run tellraw @a[team=blue] {"translate":">>> %s has retracted their forfeit vote. %s out of %s players on the team have voted to forfeit the game.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}}]}
+execute if entity @a[team=blue,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 1.. run tellraw @a[team=blue] {"translate":">>> %s has retracted their forfeit vote. %s out of the needed %s players on the team have voted to forfeit the game.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}}]}
 
 # Check if the whole blue team has forfeited
 scoreboard players set #tempBlueForfeit gameVariable 0
-execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a {"translate":">>> Blue has forfeited!"}
-execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run scoreboard players set #tempBlueForfeit gameVariable 1
+execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameVariable <= #tempForfeitCount gameVariable run tellraw @a {"translate":">>> Blue has forfeited!"}
+execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameVariable <= #tempForfeitCount gameVariable run scoreboard players set #tempBlueForfeit gameVariable 1
 
 
 #-----------------
@@ -41,17 +43,20 @@ execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameV
 
 # Count the amount of players on red team
 execute store result score #tempPlayerCount gameVariable run execute if entity @a[team=red]
+scoreboard players operation #tempPlayerCount gameVariable *= PercentPlayersToForfeit mapRules
+scoreboard players operation #tempPlayerCount gameVariable /= 100 CONST
+
 execute store result score #tempForfeitCount gameVariable run execute if entity @a[team=red,tag=VotedForfeit]
 
 # Tell players on the team someone wants to forfeit
-execute if entity @a[team=red,tag=ForfeitTriggered,tag=VotedForfeit] unless score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a[team=red] {"translate":">>> %s has voted to forfeit the game. %s out of %s players have voted to forfeit. Use [%s] to vote.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}},{"text":"/trigger gg","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger gg"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}
+execute if entity @a[team=red,tag=ForfeitTriggered,tag=VotedForfeit] if score #tempPlayerCount gameVariable > #tempForfeitCount gameVariable run tellraw @a[team=red] {"translate":">>> %s has voted to forfeit the game. %s out of the needed %s players have voted to forfeit. Use [%s] to vote.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}},{"text":"/trigger gg","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger gg"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}
 execute if entity @a[team=red,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 0 run tellraw @a[team=red] {"translate":">>> %s has retracted their forfeit vote. Voting stopped.","with":[{"selector":"@s"}]}
-execute if entity @a[team=red,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 1.. run tellraw @a[team=red] {"translate":">>> %s has retracted their forfeit vote. %s out of %s players on the team have voted to forfeit the game.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}}]}
+execute if entity @a[team=red,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 1.. run tellraw @a[team=red] {"translate":">>> %s has retracted their forfeit vote. %s out of the needed %s players on the team have voted to forfeit the game.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}}]}
 
 # Check if the whole red team has forfeited
 scoreboard players set #tempRedForfeit gameVariable 0
-execute if entity @a[team=red,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a {"translate":">>> Red has forfeited!"}
-execute if entity @a[team=red,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run scoreboard players set #tempRedForfeit gameVariable 1
+execute if entity @a[team=red,tag=VotedForfeit] if score #tempPlayerCount gameVariable <= #tempForfeitCount gameVariable run tellraw @a {"translate":">>> Red has forfeited!"}
+execute if entity @a[team=red,tag=VotedForfeit] if score #tempPlayerCount gameVariable <= #tempForfeitCount gameVariable run scoreboard players set #tempRedForfeit gameVariable 1
 
 
 #---------------------

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/trigger_gg.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/game_state/trigger_gg.mcfunction
@@ -1,17 +1,77 @@
-# Called from: moesh:tick
+# Called from: moesh:game_state/handler
 
 #---------------------------------------------------------------------------------------------------
 # Purpose: Let a player quit the game early.
 #---------------------------------------------------------------------------------------------------
 
-# Place them in spectator and advise the players
-execute if entity @a[team=blue,gamemode=!spectator,scores={gg=1..}] run tellraw @a {"translate":">>> %s forfeited for Blue!","with":[{"selector":"@s"}]}
-execute if entity @a[team=blue,gamemode=!spectator,scores={gg=1..}] run tellraw @a {"translate":"%s Red wins!","color":"red","with":[{"text":">>>","color":"white"}]}
-execute if entity @a[team=red,gamemode=!spectator,scores={gg=1..}] run tellraw @a {"translate":">>> %s forfeited for Red!","with":[{"selector":"@s"}]}
-execute if entity @a[team=red,gamemode=!spectator,scores={gg=1..}] run tellraw @a {"translate":"%s Blue wins!","color":"blue","with":[{"text":">>>","color":"white"}]}
+# Mark players who has run the gg trigger
+tag @a[team=blue,gamemode=!spectator,scores={gg=1..}] add ForfeitTriggered
+tag @a[team=red,gamemode=!spectator,scores={gg=1..}] add ForfeitTriggered
+scoreboard players set @a[scores={gg=1..}] gg 0
 
-# Reset gg trigger
-scoreboard players reset @a[scores={gg=1..}] gg
-function moesh:game_state/end_match
+# If the player retriggers gg remove their forfeit vote
+tag @a[tag=ForfeitTriggered,tag=VotedForfeit] add StopForfeit
+tag @a[tag=ForfeitTriggered,tag=!VotedForfeit] add VotedForfeit
+tag @a[tag=ForfeitTriggered,tag=StopForfeit] remove VotedForfeit
+tag @a[tag=ForfeitTriggered,tag=StopForfeit] remove StopForfeit
+
+#-----------------
+# Blue team forfeit
+#-----------------
+
+# Count the amount of players on blue team
+# And count the players who has voted for forfeit
+execute store result score #tempPlayerCount gameVariable run execute if entity @a[team=blue]
+execute store result score #tempForfeitCount gameVariable run execute if entity @a[team=blue,tag=VotedForfeit]
+
+# Tell players on the team someone wants to forfeit
+execute if entity @a[team=blue,tag=ForfeitTriggered,tag=VotedForfeit] unless score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a[team=blue] {"translate":">>> %s has voted to forfeit the game. %s out of %s players have voted to forfeit. Use [%s] to vote.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}},{"text":"/trigger gg","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger gg"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}
+execute if entity @a[team=blue,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 0 run tellraw @a[team=blue] {"translate":">>> %s has retracted their forfeit vote. Voting stopped.","with":[{"selector":"@s"}]}
+execute if entity @a[team=blue,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 1.. run tellraw @a[team=blue] {"translate":">>> %s has retracted their forfeit vote. %s out of %s players on the team have voted to forfeit the game.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}}]}
+
+# Check if the whole blue team has forfeited
+scoreboard players set #tempBlueForfeit gameVariable 0
+execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a {"translate":">>> Blue has forfeited!"}
+execute if entity @a[team=blue,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run scoreboard players set #tempBlueForfeit gameVariable 1
 
 
+#-----------------
+# Red team forfeit
+#-----------------
+
+# Count the amount of players on red team
+execute store result score #tempPlayerCount gameVariable run execute if entity @a[team=red]
+execute store result score #tempForfeitCount gameVariable run execute if entity @a[team=red,tag=VotedForfeit]
+
+# Tell players on the team someone wants to forfeit
+execute if entity @a[team=red,tag=ForfeitTriggered,tag=VotedForfeit] unless score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a[team=red] {"translate":">>> %s has voted to forfeit the game. %s out of %s players have voted to forfeit. Use [%s] to vote.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}},{"text":"/trigger gg","color":"green","clickEvent":{"action":"suggest_command","value":"/trigger gg"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}
+execute if entity @a[team=red,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 0 run tellraw @a[team=red] {"translate":">>> %s has retracted their forfeit vote. Voting stopped.","with":[{"selector":"@s"}]}
+execute if entity @a[team=red,tag=ForfeitTriggered,tag=!VotedForfeit] if score #tempForfeitCount gameVariable matches 1.. run tellraw @a[team=red] {"translate":">>> %s has retracted their forfeit vote. %s out of %s players on the team have voted to forfeit the game.","with":[{"selector":"@s"},{"score":{"name": "#tempForfeitCount","objective": "gameVariable"}},{"score":{"name": "#tempPlayerCount","objective": "gameVariable"}}]}
+
+# Check if the whole red team has forfeited
+scoreboard players set #tempRedForfeit gameVariable 0
+execute if entity @a[team=red,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run tellraw @a {"translate":">>> Red has forfeited!"}
+execute if entity @a[team=red,tag=VotedForfeit] if score #tempPlayerCount gameVariable = #tempForfeitCount gameVariable run scoreboard players set #tempRedForfeit gameVariable 1
+
+
+#---------------------
+# Check forfeit scores
+#---------------------
+
+# It's possible for both teams to forfeit at the exact same time.
+# So we check if one or both team forfeited and give the correct message based on that.
+execute if score #tempBlueForfeit gameVariable matches 1 if score #tempRedForfeit gameVariable matches 1 run tellraw @a {"translate":"%s It's a draw!","color":"gold","with":[{"text":">>>","color":"white"}]}
+execute if score #tempBlueForfeit gameVariable matches 1 if score #tempRedForfeit gameVariable matches 0 run tellraw @a {"translate":"%s Red wins!","color":"red","with":[{"text":">>>","color":"white"}]}
+execute if score #tempBlueForfeit gameVariable matches 0 if score #tempRedForfeit gameVariable matches 1 run tellraw @a {"translate":"%s Blue wins!","color":"blue","with":[{"text":">>>","color":"white"}]}
+
+# End the game if a team has forfeited
+execute if score #tempBlueForfeit gameVariable matches 1 if score #tempRedForfeit gameVariable matches 1 run function moesh:game_state/end_match
+execute if score #tempBlueForfeit gameVariable matches 0 if score #tempRedForfeit gameVariable matches 1 run function moesh:game_state/end_match
+execute if score #tempBlueForfeit gameVariable matches 1 if score #tempRedForfeit gameVariable matches 0 run function moesh:game_state/end_match
+
+# Reset scores and tags
+tag @a[tag=ForfeitTriggered] remove ForfeitTriggered
+scoreboard players reset #tempTeamForfeited gameVariable
+scoreboard players reset #tempPlayerCount gameVariable
+scoreboard players reset #tempBlueForfeit gameVariable
+scoreboard players reset #tempRedForfeit gameVariable

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/load/map_calamity_rules.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/load/map_calamity_rules.mcfunction
@@ -43,6 +43,10 @@ scoreboard objectives add mapRules dummy
     # We set the multiplayer to 5x because we want the final phase to allow for massive swings
     #   in both directions.
     scoreboard players set Phase4Multiplier mapRules 6
+
+# The percentage of players who has to trigger the gg trigger before the team will forfeit
+# Number has to be between 0(%) and 100(%).
+scoreboard players set PercentPlayersToForfeit mapRules 75
     
 # Craft items are worth points. This scoreboard tracks those points.
 # iron_nugget and iron_block have been intentionally left out.

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/player/enable_triggers.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/player/enable_triggers.mcfunction
@@ -14,6 +14,14 @@ execute if score GameState gameVariable matches 0 run scoreboard players enable 
 # Enable if the match is in progress
 execute if score GameState gameVariable matches 1 run scoreboard players reset @s gg
 execute if score GameState gameVariable matches 1 run scoreboard players enable @s gg
+# We recheck the forfeit vote to make sure it doesn't end up in an invalid state
+#
+# An invalid state could have been hit by:
+# Everyone but one players vote for forfeit.
+# The player who didn't vote leaves and another player joins in the same tick.
+# The player left check in moesh:game_state/handler would miss a player has left.
+# The forfeit vote would end up in an invalid state where everyone has voted for forfeit but the game didn't end.
+execute if score GameState gameVariable matches 1 run function moesh:game_state/trigger_gg
 
 # Enable if post-game
 execute if score GameState gameVariable matches 2 run scoreboard players reset @s reset

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/player/reset_data.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/player/reset_data.mcfunction
@@ -7,6 +7,7 @@
 
 # Tags
 tag @s remove Playing
+tag @s remove VotedForfeit
 
 # Clear player of their blessings.
 clear @s


### PR DESCRIPTION
Feature makes it so the whole team has to trigger gg to forfeit.

When a player on team triggers the gg trigger there will be message telling everyone on the team that someone wants to forfeit.
Players can retrigger gg to remove their forfeit vote.
When everyone on a team has triggered the gg trigger the team will forfeit and the opposing team will win.


The new forfeit messages I have added are quit wordy so I would suggest someone to take a look at them and change them.

