### PR TITLE
bugfix/item repair points

### DIFF
--- a/saves/calamity/datapacks/calamity/data/minecraft/recipes/repair_item.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/recipes/repair_item.json
@@ -1,0 +1,17 @@
+{
+  "comment1": "We don't really care about the content of this file.",
+  "comment2": "It's just here to replace the default repair_item recipe.",
+  "comment3": "This stops players from multiplying points by \"crafting\" iron tools using other iron tools.",
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "#"
+  ],
+  "key": {
+    "#": {
+      "item": "minecraft:bedrock"
+    }
+  },
+  "result": {
+    "item": "minecraft:bedrock"
+  }
+}


### PR DESCRIPTION
Changed the minecraft:repair_item recipe so players no longer are able to repair items in crafting tables and thereby get more points per iron.

Players can still repair items with grindstones and anvils.