### PR TITLE
feature/no-void-bridge

### DIFF
--- a/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/fix_wall.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/fix_wall.mcfunction
@@ -1,0 +1,11 @@
+# Called from: moesh:build_protection/section_small
+
+# We only really need to fix the wall at around the same y layer as the explosion happened
+# We will just do a relative fill a from a y layer a little under the explosion up to a y layer a little higher
+# Now there is a problem though. /fill doesn't work if you try to fill blocks outside the world.
+# This means that if we try and fill down at layer 0 it will fail since we can't fill from -8 up to +8 as -8 is outside the world.
+# We also don't want to fill moving_piston blocks above layer 68 since the player can't get there anyways.
+
+execute if score #tempYLocation gameVariable matches 59.. run fill ~ ~-8 ~ ~ 67 ~ minecraft:moving_piston
+execute if score #tempYLocation gameVariable matches ..9 run fill ~ 0 ~ ~ ~8 ~ minecraft:moving_piston
+execute if score #tempYLocation gameVariable matches 10..58 run fill ~ ~-8 ~ ~ ~8 ~ minecraft:moving_piston

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/handle_explosion.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/handle_explosion.mcfunction
@@ -1,0 +1,33 @@
+# Called from: moesh:build_protection/handler
+
+# A tnt has exploded. Now lets fix the walls of moving_piston blocks.
+# tnt seems to be able to blow up moving_piston up to around 5 blocks away.
+# To know where there is supposed to be moving_piston blocks after they are blown up we use marker blocks at layer y=70 
+# Now to fix the wall we just check y=70, if there is a block there then we know we have to fill in some moving_piston blocks
+#
+# Sadly there is no easy way to find all the y=70 blocks around the explosion.
+# We have to check one block at a time to see if there should be a wall or not.
+# Thats 11x11 blocks we have to check one by one. And just to be sure we should check a little more so we check 16x16 around the explosion.
+# 
+# To minimize the amount of commands we need to run we split the 16x16 section into 4 smaller sections which are 8x8 big.
+# We then check if those sections contains any blocks at y=70. If they do we split the section into smaller 4x4 sections.
+# We then go through the blocks one by one in those 4x4 sections and place moving_piston blocks if needed.
+
+execute store result score #tempYLocation gameVariable run data get entity @s Pos[1]
+
+# check if there are blocks and split into the small sections
+execute store result score #tempVar gameVariable run clone ~-8 70 ~-8 ~-1 70 ~-1 ~-8 70 ~-8 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~-4 ~ ~-4 run function moesh:build_protection/section_medium
+
+execute store result score #tempVar gameVariable run clone ~-8 70 ~0 ~-1 70 ~7 ~-8 70 ~0 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~-4 ~ ~3 run function moesh:build_protection/section_medium
+
+execute store result score #tempVar gameVariable run clone ~0 70 ~-8 ~7 70 ~-1 ~0 70 ~-8 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~3 ~ ~-4 run function moesh:build_protection/section_medium
+
+execute store result score #tempVar gameVariable run clone ~0 70 ~0 ~7 70 ~7 ~0 70 ~0 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~3 ~ ~3 run function moesh:build_protection/section_medium
+
+# Reset our temp variables
+scoreboard players reset #tempVar gameVariable
+scoreboard players reset #tempYLocation gameVariable

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/handler.mcfunction
@@ -1,0 +1,25 @@
+# Called from: moesh:tick
+
+# Players shouldn't be able to place blocks over the void.
+# To stop this we use "moving_piston" blocks which normally are used for marking blocks which are being pushed.
+#
+# Players cannot place blocks on moving_piston blocks. The block can not be pushed. Water can't flow through them.
+# The block has no hitbox so arrows can fly through them.
+# The only problem with the block is that tnt can blow it up.
+# To fix this we have to find all tnt which are about to explode and fix the destroyed walls of moving_piston blocks.
+#
+#
+# Extra notes about moving_piston:
+# Normally the block has tile entity data to store information about the pushed block, but when setblocked it won't.
+# This is lucky for us since tile entities in big amounts can be laggy. So we shouldn't get any perfomance issues from having a ton of these blocks.
+#
+# moving_piston doesn't drop any items when it doesn't have tile entity data.
+# If it did drop items then we could simple just execute at those items and place new blocks to fix the explosion damage.
+#
+# moving_piston blocks doesn't have any blast resistance so it shouldn't mess with the tnt explosions.
+
+
+# We can't detect the tnt after it has exploded.
+# We summon a marker entity at tnt which is about to explode so we can use the tnt's location after it has blown up.
+execute as @e[tag=ExplosionMarker] at @s run function moesh:build_protection/handle_explosion
+execute as @e[type=tnt,nbt={Fuse:1s}] at @s run summon minecraft:area_effect_cloud ~ ~ ~ {Duration:2,Tags:["ExplosionMarker"]}

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/section_medium.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/section_medium.mcfunction
@@ -1,0 +1,14 @@
+# Called from: moesh:build_protection/handle_explosion
+
+# Do the split into 4x4 sections.
+execute store result score #tempVar gameVariable run clone ~-4 70 ~-4 ~-1 70 ~-1 ~-4 70 ~-4 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~-4 ~ ~-4 run function moesh:build_protection/section_small
+
+execute store result score #tempVar gameVariable run clone ~-4 70 ~0 ~-1 70 ~3 ~-4 70 ~0 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~-4 ~ ~0 run function moesh:build_protection/section_small
+
+execute store result score #tempVar gameVariable run clone ~0 70 ~-4 ~3 70 ~-1 ~0 70 ~-4 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~0 ~ ~-4 run function moesh:build_protection/section_small
+
+execute store result score #tempVar gameVariable run clone ~0 70 ~0 ~3 70 ~3 ~0 70 ~0 filtered minecraft:structure_void force
+execute if score #tempVar gameVariable matches 1.. positioned ~0 ~ ~0 run function moesh:build_protection/section_small

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/section_small.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/section_small.mcfunction
@@ -1,0 +1,19 @@
+# Called from: moesh:build_protection/section_medium
+
+# Check if there is supposed to be a moving_piston wall and fix the wall
+execute positioned ~0 ~ ~0 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~1 ~ ~0 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~2 ~ ~0 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~3 ~ ~0 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~0 ~ ~1 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~1 ~ ~1 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~2 ~ ~1 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~3 ~ ~1 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~0 ~ ~2 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~1 ~ ~2 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~2 ~ ~2 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~3 ~ ~2 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~0 ~ ~3 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~1 ~ ~3 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~2 ~ ~3 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall
+execute positioned ~3 ~ ~3 if block ~ 70 ~ minecraft:structure_void run function moesh:build_protection/fix_wall

--- a/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/setup_wall.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/moesh/functions/build_protection/setup_wall.mcfunction
@@ -1,0 +1,19 @@
+# This function is used for setting up the moving_piston walls.
+# Call this function manually while standing on a structure void to make the moving_piston walls for all connected structure void.
+# Structure void is expected to be at layer 70.
+
+#replace structure void with air so it wont be detected again
+setblock ~ ~ ~ air
+
+fill ~ 0 ~ ~ 67 ~ moving_piston
+execute positioned ~1 ~ ~ if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~-1 ~ ~ if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~ ~ ~1 if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~ ~ ~-1 if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~1 ~ ~-1 if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~1 ~ ~1 if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~-1 ~ ~-1 if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+execute positioned ~-1 ~ ~1 if block ~ ~ ~ structure_void run function moesh:build_protection/setup_wall
+
+# place the structure void back
+setblock ~ ~ ~ structure_void

--- a/saves/calamity/datapacks/calamity/data/moesh/tags/functions/tick_match.json
+++ b/saves/calamity/datapacks/calamity/data/moesh/tags/functions/tick_match.json
@@ -1,6 +1,7 @@
 {
         "values": [
                 "moesh:resource_point/handler",
-                "moesh:points/handler"
+                "moesh:points/handler",
+                "moesh:build_protection/handler"
 	]
 }


### PR DESCRIPTION
Features adds the needed things to stop players from placing blocks in certain places.

The block `minecraft:moving_piston` has the special properties that it has no hitbox (so entities can go through), players can't place blocks in them and pistons can't push them.
By encapsulating the whole map in the block players will no longer be able to bridge out and over the void.

The block has one problem though which is that it can be blown up.
This feature fixes that problem by placing the blocks back when they have been blown up.

This feature doesn't do all the needed setup though. There is some setup you have to do to get it up and running:
1. On layer 70 place `minecraft:structure_void` around the map where the player isn't supposed to be able to bridge through.
2. Stand in one of the placed structure voids and run `/function moesh:build_protection/setup_wall`. This will place `minecraft:moving_piston` under all the `structure_void` blocks connected to the one you are standing on.

Note that this feature only fixes the problem with tnt blowing up the blocks and doesn't fix the walls if eg. a creeper blows up.