### PR TITLE
Feature/spawn items

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/detect_double_items_start.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/detect_double_items_start.json
@@ -1,0 +1,22 @@
+{
+    "comment": "Advancment used for detecting if the player is in a state where they might have 2 spawn items",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/setup_double_check"
+    },
+    "criteria": {
+        "inventory_changed": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "player": {
+                    "nbt": "{Inventory:[{tag:{Calamity:{SpawnItem:1b,SpawnSelectionItem:0b}}}]}"
+                }
+            }
+        }
+    },
+    "requirements": [
+        [
+            "inventory_changed"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/detect_repaired_starting_items.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/detect_repaired_starting_items.json
@@ -1,0 +1,25 @@
+{
+    "comment": "Advancement used for detecting if a player has used one of their starting items in a grindstone/anvil to repair an item",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/clear_repaired_items"
+    },
+    "criteria": {
+        "repaired_item": {
+        	"trigger": "minecraft:inventory_changed",
+        	"conditions": {
+            	"items": [
+                	{
+                    	"tag": "calamity:spawn_item",
+                    	"nbt": "{Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}],RepairCost:1}"
+                	}
+            	]
+        	}
+		}
+  	},
+  	"requirements": [
+    	[
+			"repaired_item"
+    	]
+  	]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/detect_spawn_item.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/detect_spawn_item.json
@@ -1,0 +1,32 @@
+{
+    "comment1": "Advancement used for detecting if a player has one of the starting items",
+    "comment2": "advancement_lock is used for locking/unlocking the advancement so the player only can get it sometimes",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/clear_spawn_items"
+    },
+    "criteria": {
+        "spawn_item": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "tag": "calamity:spawn_item",
+                        "nbt": "{Calamity:{SpawnSelectionItem:1b}}"
+                    }
+                ]
+            }
+        },
+        "advancement_lock": {
+            "trigger": "minecraft:impossible"
+        }
+    },
+    "requirements": [
+        [
+            "spawn_item"
+        ],
+        [
+            "advancement_lock"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/hidden_root.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/hidden_root.json
@@ -1,0 +1,12 @@
+{
+    "criteria": {
+      "impossible": {
+        "trigger": "minecraft:impossible"
+      }
+    },
+    "requirements": [
+      [
+        "impossible"
+      ]
+    ]
+  }

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_0.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_0.json
@@ -1,0 +1,22 @@
+{
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/used_item/used_item_0"
+    },
+    "criteria": {
+        "used_item": {
+        	"trigger": "minecraft:item_durability_changed",
+        	"conditions": {
+            	"item": {
+                    "tag": "calamity:spawn_item",
+                    "nbt": "{Calamity:{SpawnItem:1b,SpawnSelectionItem:1b,SpawnItemId:100b}}"
+                }
+        	}
+    	}
+  	},
+  	"requirements": [
+    	[
+      		"used_item"
+    	]
+  	]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_1.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_1.json
@@ -1,0 +1,22 @@
+{
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/used_item/used_item_1"
+    },
+    "criteria": {
+        "used_item": {
+        	"trigger": "minecraft:item_durability_changed",
+        	"conditions": {
+            	"item": {
+                    "tag": "calamity:spawn_item",
+                    "nbt": "{Calamity:{SpawnItem:1b,SpawnSelectionItem:1b,SpawnItemId:101b}}"
+                }
+        	}
+    	}
+  	},
+  	"requirements": [
+    	[
+      		"used_item"
+    	]
+  	]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_2.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_2.json
@@ -1,0 +1,22 @@
+{
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/used_item/used_item_2"
+    },
+    "criteria": {
+        "used_item": {
+        	"trigger": "minecraft:item_durability_changed",
+        	"conditions": {
+            	"item": {
+                    "tag": "calamity:spawn_item",
+                    "nbt": "{Calamity:{SpawnItem:1b,SpawnSelectionItem:1b,SpawnItemId:102b}}"
+                }
+        	}
+    	}
+  	},
+  	"requirements": [
+    	[
+      		"used_item"
+    	]
+  	]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_3.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_3.json
@@ -1,0 +1,22 @@
+{
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/used_item/used_item_3"
+    },
+    "criteria": {
+        "used_item": {
+        	"trigger": "minecraft:item_durability_changed",
+        	"conditions": {
+            	"item": {
+                    "tag": "calamity:spawn_item",
+                    "nbt": "{Calamity:{SpawnItem:1b,SpawnSelectionItem:1b,SpawnItemId:103b}}"
+                }
+        	}
+    	}
+  	},
+  	"requirements": [
+    	[
+      		"used_item"
+    	]
+  	]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_4.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/used_item/used_item_4.json
@@ -1,0 +1,22 @@
+{
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/used_item/used_item_4"
+    },
+    "criteria": {
+        "used_item": {
+        	"trigger": "minecraft:item_durability_changed",
+        	"conditions": {
+            	"item": {
+                    "tag": "calamity:spawn_item",
+                    "nbt": "{Calamity:{SpawnItem:1b,SpawnSelectionItem:1b,SpawnItemId:104b}}"
+                }
+        	}
+    	}
+  	},
+  	"requirements": [
+    	[
+      		"used_item"
+    	]
+  	]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/handler.mcfunction
@@ -25,6 +25,10 @@ execute if score GameState gameVariable matches 0 if score StartingMatch gameVar
 # Prevent players from leaving the play area
 # TODO: execute as @a at @s unless entity @s[gamemode=spectator] if score GameState gameVariable matches 1 run function calamity:game_state/out_of_bounds
 
+# Handle the spawn items
+execute if score GameState gameVariable matches 1 as @a[tag=Playing] run function calamity:player/spawn_items/handler
+kill @e[type=item,nbt={Item:{tag:{Calamity:{SpawnItem:1b}}}}]
+
 # Count the players and check if someone left. If they did recheck forfeit state
 #
 # The forfeit check normally only happens when someone triggers the gg trigger

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/start_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/start_match.mcfunction
@@ -53,6 +53,9 @@ spawnpoint @a[team=blue] 159 45 90
 tp @a[team=red] 113 45 90
 spawnpoint @a[team=red] 113 45 90
 
+# Give players the starting item selection
+scoreboard players set @a[tag=Playing] giveSpawnItems 1
+
 # Send tellraw BEFORE changing any game modes!
 tellraw @a {"translate":"%s Go cause a calamity!","color":"green","with":[{"text":">>>","color":"white"}]}
 tellraw @a {"translate":"%s Phase %s begins! %sx points multiplier.","color":"green","with":[{"text":">>>","color":"white"},{"translate":"1","color":"white"},{"score":{"name":"PhaseMultiplier","objective":"gameVariable"},"color":"white"}]}

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/load/setup_scoreboards.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/load/setup_scoreboards.mcfunction
@@ -75,6 +75,12 @@ scoreboard objectives add SessionID dummy
 scoreboard objectives remove leaveGame
 scoreboard objectives add leaveGame minecraft.custom:minecraft.leave_game
 
+# Player scores
+scoreboard objectives remove selectedItem
+scoreboard objectives add selectedItem dummy
+scoreboard objectives remove giveSpawnItems
+scoreboard objectives add giveSpawnItems deathCount
+
 # Player triggers
 # These are ALWAYS reset when they are enabled. Players have no score by default.
 # Enabled during the match. Players are moved to spectator if they want to gg out early.

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/clear_repaired_items.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/clear_repaired_items.mcfunction
@@ -1,0 +1,6 @@
+# called from the advancement calamity:spawn_items/detect_repaired_starting_items
+
+tag @s add ClearRepairedStartingItems
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/detect_repaired_starting_items

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/clear_spawn_items.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/clear_spawn_items.mcfunction
@@ -1,0 +1,7 @@
+# called from the advancement calamity:spawn_items/detect_repaired_starting_items
+
+tag @s add ClearStartingItems
+
+# revoke the advancement and grant advancement lock so the player can get it again
+advancement revoke @s only calamity:spawn_items/detect_spawn_item
+advancement grant @s only calamity:spawn_items/detect_spawn_item advancement_lock

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
@@ -1,0 +1,14 @@
+# Revoke spawn item advancements both to clean up, but also to allow players to have spawn items again 
+advancement revoke @s from calamity:spawn_items/hidden_root
+advancement grant @s only calamity:spawn_items/hidden_root
+
+# Reset scores
+scoreboard players set @s selectedItem -1
+scoreboard players set @s giveSpawnItems 0
+
+# Give starting items
+loot give @s loot calamity:spawn_items/item0
+loot give @s loot calamity:spawn_items/item1
+loot give @s loot calamity:spawn_items/item2
+loot give @s loot calamity:spawn_items/item3
+loot give @s loot calamity:spawn_items/item4

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
@@ -1,0 +1,24 @@
+# When an item changing command is called from a function which was granted by an advancement triggered by an inventory changed
+# the items sometimes don't visually update.
+# To fix this we give the player a tag to show what change we want to make to the inventory and then make that change in here.
+
+# Clear starting items
+execute if entity @s[tag=ClearStartingItems] run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:1b}}
+tag @s[tag=ClearStartingItems] remove ClearStartingItems
+
+# Clear items repaired with starting items
+execute if entity @s[tag=ClearRepairedStartingItems] run clear @s[gamemode=!creative] #calamity:spawn_item{Enchantments:[{id:"minecraft:vanishing_curse",lvl:10s}],RepairCost:1}
+tag @s[tag=ClearRepairedStartingItems] remove ClearRepairedStartingItems
+
+# Detect if the player has 2 selected starting items and clear one of them
+execute if entity @s[tag=DetectDoubleItems] store result score #tempVar gameVariable run clear @s #calamity:spawn_item{Calamity:{SpawnItem:1b}} 0
+execute if entity @s[tag=DetectDoubleItems] if score #tempVar gameVariable matches 2.. run clear @s #calamity:spawn_item{Calamity:{SpawnItem:1b,SpawnSelectionItem:0b}} 1
+tag @s[tag=DetectDoubleItems] remove DetectDoubleItems
+scoreboard players reset #tempVar gameVariable
+
+# Give the player their chosen item
+execute if entity @s[tag=GiveSelectedStartingItem] run function calamity:player/spawn_items/regive_chosen_item
+tag @s[tag=GiveSelectedStartingItem] remove GiveSelectedStartingItem
+
+# On death give selection items
+execute if entity @s[scores={giveSpawnItems=1..}] run function calamity:player/spawn_items/give_items

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/regive_chosen_item.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/regive_chosen_item.mcfunction
@@ -1,0 +1,29 @@
+# Called from calamity:player/spawn_items/handler
+
+# Make it so the player won't be allowed to have spawn selection items any more
+advancement grant @s only calamity:spawn_items/detect_spawn_item advancement_lock
+
+# Get the ids of the tools in the player's hands
+scoreboard players set #tempMainHandId gameVariable 0
+scoreboard players set #tempOffHandId gameVariable 0
+scoreboard players set #tempFoundItemId gameVariable 0
+
+execute store result score #tempMainHandId gameVariable run data get entity @s SelectedItem.tag.Calamity.SpawnItemId
+execute store result score #tempOffHandId gameVariable run data get entity @s Inventory[{Slot:-106b}].tag.Calamity.SpawnItemId
+
+# Clear the selection items
+function calamity:player/spawn_items/clear_spawn_items
+
+# Regive the selected item and put it at the same location
+execute if score @s selectedItem = #tempMainHandId gameVariable run loot replace entity @s weapon.mainhand loot calamity:spawn_items/give_item_from_score
+execute if score @s selectedItem = #tempMainHandId gameVariable run scoreboard players set #tempFoundItemId gameVariable 1
+
+execute if score #tempFoundItemId gameVariable matches 0 if score @s selectedItem = #tempOffHandId gameVariable run loot replace entity @s weapon.offhand loot calamity:spawn_items/give_item_from_score
+execute if score @s selectedItem = #tempOffHandId gameVariable run scoreboard players set #tempFoundItemId gameVariable 1
+
+execute if score #tempFoundItemId gameVariable matches 0 run loot give @s loot calamity:spawn_items/give_item_from_score
+
+# Clear up our temp variables
+scoreboard players reset #tempMainHandId gameVariable
+scoreboard players reset #tempOffHandId gameVariable
+scoreboard players reset #tempFoundItemId gameVariable

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/setup_double_check.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/setup_double_check.mcfunction
@@ -1,0 +1,6 @@
+# called from the advancement calamity:spawn_items/detect_double_items_start
+
+tag @s add DetectDoubleItems
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/detect_double_items_start

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_0.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_0.mcfunction
@@ -1,0 +1,7 @@
+# called from the advancement calamity:spawn_items/used_item/used_item_0
+
+tag @s add GiveSelectedStartingItem
+scoreboard players set @s selectedItem 100
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/used_item/used_item_0

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_1.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_1.mcfunction
@@ -1,0 +1,7 @@
+# called from the advancement calamity:spawn_items/used_item/used_item_1
+
+tag @s add GiveSelectedStartingItem
+scoreboard players set @s selectedItem 101
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/used_item/used_item_1

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_2.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_2.mcfunction
@@ -1,0 +1,7 @@
+# called from the advancement calamity:spawn_items/used_item/used_item_2
+
+tag @s add GiveSelectedStartingItem
+scoreboard players set @s selectedItem 102
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/used_item/used_item_2

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_3.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_3.mcfunction
@@ -1,0 +1,7 @@
+# called from the advancement calamity:spawn_items/used_item/used_item_3
+
+tag @s add GiveSelectedStartingItem
+scoreboard players set @s selectedItem 103
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/used_item/used_item_3

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_4.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/used_item/used_item_4.mcfunction
@@ -1,0 +1,7 @@
+# called from the advancement calamity:spawn_items/used_item/used_item_4
+
+tag @s add GiveSelectedStartingItem
+scoreboard players set @s selectedItem 104
+
+# revoke the advancement so the player can get it again
+advancement revoke @s only calamity:spawn_items/used_item/used_item_4

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/give_item_from_score.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/give_item_from_score.json
@@ -1,0 +1,94 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "entity_scores",
+                    "entity": "this",
+                    "scores": {
+                        "selectedItem": 100
+                    }
+                }
+            ],
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "name": "calamity:spawn_items/item0"
+                }
+            ]
+        },
+        {
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "entity_scores",
+                    "entity": "this",
+                    "scores": {
+                        "selectedItem": 101
+                    }
+                }
+            ],
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "name": "calamity:spawn_items/item1"
+                }
+            ]
+        },
+        {
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "entity_scores",
+                    "entity": "this",
+                    "scores": {
+                        "selectedItem": 102
+                    }
+                }
+            ],
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "name": "calamity:spawn_items/item2"
+                }
+            ]
+        },
+        {
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "entity_scores",
+                    "entity": "this",
+                    "scores": {
+                        "selectedItem": 103
+                    }
+                }
+            ],
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "name": "calamity:spawn_items/item3"
+                }
+            ]
+        },
+        {
+            "rolls": 1,
+            "conditions": [
+                {
+                    "condition": "entity_scores",
+                    "entity": "this",
+                    "scores": {
+                        "selectedItem": 104
+                    }
+                }
+            ],
+            "entries": [
+                {
+                    "type": "loot_table",
+                    "name": "calamity:spawn_items/item4"
+                }
+            ]
+        }
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item0.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item0.json
@@ -1,0 +1,49 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "weight": 1,
+                    "type": "item",
+                    "name": "minecraft:iron_axe",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:100b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": -1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": {
+                                            "min": 0,
+                                            "max": 2147483647
+                                        }
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item1.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item1.json
@@ -1,0 +1,49 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "weight": 1,
+                    "type": "item",
+                    "name": "minecraft:iron_sword",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:101b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": -1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": {
+                                            "min": 0,
+                                            "max": 2147483647
+                                        }
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item2.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item2.json
@@ -1,0 +1,49 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "weight": 1,
+                    "type": "item",
+                    "name": "minecraft:iron_pickaxe",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:102b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": -1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": {
+                                            "min": 0,
+                                            "max": 2147483647
+                                        }
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item3.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item3.json
@@ -1,0 +1,49 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "weight": 1,
+                    "type": "item",
+                    "name": "minecraft:iron_shovel",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:103b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": -1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": {
+                                            "min": 0,
+                                            "max": 2147483647
+                                        }
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item4.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item4.json
@@ -1,0 +1,49 @@
+{
+    "pools": [
+        {
+            "rolls": 1,
+            "entries": [
+                {
+                    "weight": 1,
+                    "type": "item",
+                    "name": "minecraft:iron_hoe",
+                    "functions": [
+                        {
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:104b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": -1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "selectedItem": {
+                                            "min": 0,
+                                            "max": 2147483647
+                                        }
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/tags/items/spawn_item.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/tags/items/spawn_item.json
@@ -1,0 +1,10 @@
+{
+    "replace": false,
+    "values": [
+      "minecraft:iron_axe",
+      "minecraft:iron_sword",
+      "minecraft:iron_pickaxe",
+      "minecraft:iron_shovel",
+      "minecraft:iron_hoe"
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/minecraft/advancements/recipes/misc/iron_nugget_from_blasting.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/advancements/recipes/misc/iron_nugget_from_blasting.json
@@ -1,0 +1,14 @@
+{
+  "comment": "This file exists to override the old advancement which gave the player the iron nugget smelting recipe",
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "requirements": [
+    [
+      "impossible"
+    ]
+  ]
+}

--- a/saves/calamity/datapacks/calamity/data/minecraft/advancements/recipes/misc/iron_nugget_from_smelting.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/advancements/recipes/misc/iron_nugget_from_smelting.json
@@ -1,0 +1,14 @@
+{
+  "comment": "This file exists to override the old advancement which gave the player the iron nugget smelting recipe",
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "impossible": {
+      "trigger": "minecraft:impossible"
+    }
+  },
+  "requirements": [
+    [
+      "impossible"
+    ]
+  ]
+}

--- a/saves/calamity/datapacks/calamity/data/minecraft/recipes/iron_nugget_from_blasting.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/recipes/iron_nugget_from_blasting.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Overrides the normal iron tools -> iron nuggets recipes",
+  "type": "minecraft:blasting",
+  "ingredient": [
+    {
+      "item": "minecraft:bedrock"
+    }
+  ],
+  "result": "minecraft:bedrock",
+  "experience": 0,
+  "cookingtime": 2147483647
+}

--- a/saves/calamity/datapacks/calamity/data/minecraft/recipes/iron_nugget_from_smelting.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/recipes/iron_nugget_from_smelting.json
@@ -1,0 +1,12 @@
+{
+  "comment": "Overrides the normal iron tools -> iron nuggets recipes",
+  "type": "minecraft:smelting",
+  "ingredient": [
+    {
+      "item": "minecraft:bedrock"
+    }
+  ],
+  "result": "minecraft:bedrock",
+  "experience": 0,
+  "cookingtime": 2147483647
+}


### PR DESCRIPTION
Fixes #19

Feature makes it so players spawn with a set of iron tools.
When the player uses one of the items (as in it loses durability) all the other tools will be removed and they will get to keep the tool the used.


Pretty sure I have made it impossible for players to cheat the system. This includes removing the iron tool smelting recipes (which gave iron nuggets), kill all dropped spawn items, clear none selected spawn items from players who have done a selection in case they ever would get any (eg. through chests), made it impossible for players to have more than one selected starting item on them (again incase they pick one up from a chest) and made it so all items repaired with starting items are removed.


The starting items can be changed inside of the files `loot_tables/spawn_items/itemX.json`. The items are given from loot tables for 2 reasons:
1. They are given in multiple different ways, by using a loot table file the item is only defined once.
2. In 1.17 they are replacing the `/replaceitem` command which is the command used for placing items in exact slots in the inventory. To be a little more future proof this feature is using `/loot` instead which takes loot from a loot table and puts it into a slot.


Note that if you change the spawn items to diffferent types of items you will have to add the ids to the `spawn_item` item tag (`tags/items/spawn_item.json`).