### PR TITLE
Bugfix/26 items first time

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_0.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_0.json
@@ -1,0 +1,26 @@
+{
+    "comment1": "Advancement used for detecting if a player has a spawn item of the type in their inventory",
+    "comment2": "(This is used for detecting if a player has spawn item they shouldn't have)",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/has_item/has_item_0"
+    },
+    "criteria": {
+        "has_the_item": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "tag": "calamity:spawn_item",
+                        "nbt": "{Calamity:{SpawnSelectionItem:0b,SpawnItemId:100b}}"
+                    }
+                ]
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_item"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_1.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_1.json
@@ -1,0 +1,26 @@
+{
+    "comment1": "Advancement used for detecting if a player has a spawn item of the type in their inventory",
+    "comment2": "(This is used for detecting if a player has spawn item they shouldn't have)",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/has_item/has_item_1"
+    },
+    "criteria": {
+        "has_the_item": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "tag": "calamity:spawn_item",
+                        "nbt": "{Calamity:{SpawnSelectionItem:0b,SpawnItemId:101b}}"
+                    }
+                ]
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_item"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_2.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_2.json
@@ -1,0 +1,26 @@
+{
+    "comment1": "Advancement used for detecting if a player has a spawn item of the type in their inventory",
+    "comment2": "(This is used for detecting if a player has spawn item they shouldn't have)",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/has_item/has_item_2"
+    },
+    "criteria": {
+        "has_the_item": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "tag": "calamity:spawn_item",
+                        "nbt": "{Calamity:{SpawnSelectionItem:0b,SpawnItemId:102b}}"
+                    }
+                ]
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_item"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_3.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_3.json
@@ -1,0 +1,26 @@
+{
+    "comment1": "Advancement used for detecting if a player has a spawn item of the type in their inventory",
+    "comment2": "(This is used for detecting if a player has spawn item they shouldn't have)",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/has_item/has_item_3"
+    },
+    "criteria": {
+        "has_the_item": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "tag": "calamity:spawn_item",
+                        "nbt": "{Calamity:{SpawnSelectionItem:0b,SpawnItemId:103b}}"
+                    }
+                ]
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_item"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_4.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/spawn_items/has_item/has_item_4.json
@@ -1,0 +1,26 @@
+{
+    "comment1": "Advancement used for detecting if a player has a spawn item of the type in their inventory",
+    "comment2": "(This is used for detecting if a player has spawn item they shouldn't have)",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:player/spawn_items/has_item/has_item_4"
+    },
+    "criteria": {
+        "has_the_item": {
+            "trigger": "minecraft:inventory_changed",
+            "conditions": {
+                "items": [
+                    {
+                        "tag": "calamity:spawn_item",
+                        "nbt": "{Calamity:{SpawnSelectionItem:0b,SpawnItemId:104b}}"
+                    }
+                ]
+            }
+        }
+    },
+    "requirements": [
+        [
+            "has_the_item"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/start_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/start_match.mcfunction
@@ -53,7 +53,8 @@ spawnpoint @a[team=blue] 159 45 90
 tp @a[team=red] 113 45 90
 spawnpoint @a[team=red] 113 45 90
 
-# Give players the starting item selection
+# Reset players item selection and give players the starting item selection
+scoreboard players set @a selectedItem -1
 scoreboard players set @a[tag=Playing] giveSpawnItems 1
 
 # Send tellraw BEFORE changing any game modes!

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
@@ -1,14 +1,19 @@
+# Called form calamity:player/spawn_items/handler
+# (Called after player has died)
+
 # Revoke spawn item advancements both to clean up, but also to allow players to have spawn items again 
 advancement revoke @s from calamity:spawn_items/hidden_root
 advancement grant @s only calamity:spawn_items/hidden_root
 
-# Reset scores
-scoreboard players set @s selectedItem -1
-scoreboard players set @s giveSpawnItems 0
+# Give starting items if player hasn't selected an item
+execute if score @s selectedItem matches -1 run loot give @s loot calamity:spawn_items/item0
+execute if score @s selectedItem matches -1 run loot give @s loot calamity:spawn_items/item1
+execute if score @s selectedItem matches -1 run loot give @s loot calamity:spawn_items/item2
+execute if score @s selectedItem matches -1 run loot give @s loot calamity:spawn_items/item3
+execute if score @s selectedItem matches -1 run loot give @s loot calamity:spawn_items/item4
 
-# Give starting items
-loot give @s loot calamity:spawn_items/item0
-loot give @s loot calamity:spawn_items/item1
-loot give @s loot calamity:spawn_items/item2
-loot give @s loot calamity:spawn_items/item3
-loot give @s loot calamity:spawn_items/item4
+# Give the selected item if the player has selected an item
+execute unless score @s selectedItem matches -1 run function calamity:player/spawn_items/regive_chosen_item
+
+# Reset death score
+scoreboard players set @s giveSpawnItems 0

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
@@ -6,14 +6,25 @@
 execute if entity @s[tag=ClearStartingItems] run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:1b}}
 tag @s[tag=ClearStartingItems] remove ClearStartingItems
 
+# Clear items which are of a different type than the type the player selected
+execute if entity @s[tag=clearWrongSpawnItems] unless score @s selectedItem matches 100 run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:0b,SpawnItemId:100b}}
+execute if entity @s[tag=clearWrongSpawnItems] unless score @s selectedItem matches 101 run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:0b,SpawnItemId:101b}}
+execute if entity @s[tag=clearWrongSpawnItems] unless score @s selectedItem matches 102 run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:0b,SpawnItemId:102b}}
+execute if entity @s[tag=clearWrongSpawnItems] unless score @s selectedItem matches 103 run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:0b,SpawnItemId:103b}}
+execute if entity @s[tag=clearWrongSpawnItems] unless score @s selectedItem matches 104 run clear @s[gamemode=!creative] #calamity:spawn_item{Calamity:{SpawnSelectionItem:0b,SpawnItemId:104b}}
+tag @s[tag=clearWrongSpawnItems] remove clearWrongSpawnItems
+
 # Clear items repaired with starting items
 execute if entity @s[tag=ClearRepairedStartingItems] run clear @s[gamemode=!creative] #calamity:spawn_item{Enchantments:[{id:"minecraft:vanishing_curse",lvl:10s}],RepairCost:1}
 tag @s[tag=ClearRepairedStartingItems] remove ClearRepairedStartingItems
 
 # Detect if the player has 2 selected starting items and clear one of them
-execute if entity @s[tag=DetectDoubleItems] store result score #tempVar gameVariable run clear @s #calamity:spawn_item{Calamity:{SpawnItem:1b}} 0
-execute if entity @s[tag=DetectDoubleItems] if score #tempVar gameVariable matches 2.. run clear @s #calamity:spawn_item{Calamity:{SpawnItem:1b,SpawnSelectionItem:0b}} 1
+# Using an extra tag here so the player can get the tag again when an item is cleared
+tag @s[tag=DetectDoubleItems] add DetectedDoubleItems
 tag @s[tag=DetectDoubleItems] remove DetectDoubleItems
+execute if entity @s[tag=DetectedDoubleItems] store result score #tempVar gameVariable run clear @s #calamity:spawn_item{Calamity:{SpawnItem:1b}} 0
+execute if entity @s[tag=DetectedDoubleItems] if score #tempVar gameVariable matches 2.. run clear @s #calamity:spawn_item{Calamity:{SpawnItem:1b,SpawnSelectionItem:0b}} 1
+tag @s[tag=DetectedDoubleItems] remove DetectedDoubleItems
 scoreboard players reset #tempVar gameVariable
 
 # Give the player their chosen item

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_0.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_0.mcfunction
@@ -1,0 +1,8 @@
+# called from the advancement calamity:spawn_items/has_item/has_item_0
+
+# Tag player if they aren't supposed to have the item.
+execute unless score @s selectedItem matches 100 run tag @s add clearWrongSpawnItems
+
+# Revoke advancement so the player can get it again.
+# Notice advancement is only revoked if the player isn't supposed to have the item.
+execute unless score @s selectedItem matches 100 run advancement revoke @s only calamity:spawn_items/has_item/has_item_0

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_1.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_1.mcfunction
@@ -1,0 +1,8 @@
+# called from the advancement calamity:spawn_items/has_item/has_item_0
+
+# Tag player if they aren't supposed to have the item.
+execute unless score @s selectedItem matches 101 run tag @s add clearWrongSpawnItems
+
+# Revoke advancement so the player can get it again.
+# Notice advancement is only revoked if the player isn't supposed to have the item.
+execute unless score @s selectedItem matches 101 run advancement revoke @s only calamity:spawn_items/has_item/has_item_1

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_2.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_2.mcfunction
@@ -1,0 +1,8 @@
+# called from the advancement calamity:spawn_items/has_item/has_item_0
+
+# Tag player if they aren't supposed to have the item.
+execute unless score @s selectedItem matches 102 run tag @s add clearWrongSpawnItems
+
+# Revoke advancement so the player can get it again.
+# Notice advancement is only revoked if the player isn't supposed to have the item.
+execute unless score @s selectedItem matches 102 run advancement revoke @s only calamity:spawn_items/has_item/has_item_2

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_3.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_3.mcfunction
@@ -1,0 +1,8 @@
+# called from the advancement calamity:spawn_items/has_item/has_item_0
+
+# Tag player if they aren't supposed to have the item.
+execute unless score @s selectedItem matches 103 run tag @s add clearWrongSpawnItems
+
+# Revoke advancement so the player can get it again.
+# Notice advancement is only revoked if the player isn't supposed to have the item.
+execute unless score @s selectedItem matches 103 run advancement revoke @s only calamity:spawn_items/has_item/has_item_3

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_4.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/has_item/has_item_4.mcfunction
@@ -1,0 +1,8 @@
+# called from the advancement calamity:spawn_items/has_item/has_item_0
+
+# Tag player if they aren't supposed to have the item.
+execute unless score @s selectedItem matches 104 run tag @s add clearWrongSpawnItems
+
+# Revoke advancement so the player can get it again.
+# Notice advancement is only revoked if the player isn't supposed to have the item.
+execute unless score @s selectedItem matches 104 run advancement revoke @s only calamity:spawn_items/has_item/has_item_4

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item0.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item0.json
@@ -10,20 +10,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:100b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
-                        },
-                        {
-                            "conditions": [
-                                {
-                                    "condition": "entity_scores",
-                                    "entity": "this",
-                                    "scores": {
-                                        "selectedItem": -1
-                                    }
-                                }
-                            ],
-                            "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:100b,SpawnSelectionItem:1b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
                         },
                         {
                             "conditions": [
@@ -40,6 +27,19 @@
                             ],
                             "function": "set_nbt",
                             "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "giveSpawnItems": 1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Damage:240}"
                         }
                     ]
                 }

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item0.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item0.json
@@ -26,7 +26,7 @@
                                 }
                             ],
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241,CustomModelData:2}"
                         },
                         {
                             "conditions": [

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item1.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item1.json
@@ -10,20 +10,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:101b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
-                        },
-                        {
-                            "conditions": [
-                                {
-                                    "condition": "entity_scores",
-                                    "entity": "this",
-                                    "scores": {
-                                        "selectedItem": -1
-                                    }
-                                }
-                            ],
-                            "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:101b,SpawnSelectionItem:1b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
                         },
                         {
                             "conditions": [
@@ -40,6 +27,19 @@
                             ],
                             "function": "set_nbt",
                             "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "giveSpawnItems": 1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Damage:240}"
                         }
                     ]
                 }

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item1.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item1.json
@@ -26,7 +26,7 @@
                                 }
                             ],
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241,CustomModelData:2}"
                         },
                         {
                             "conditions": [

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item2.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item2.json
@@ -26,7 +26,7 @@
                                 }
                             ],
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241,CustomModelData:2}"
                         },
                         {
                             "conditions": [

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item2.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item2.json
@@ -10,20 +10,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:102b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
-                        },
-                        {
-                            "conditions": [
-                                {
-                                    "condition": "entity_scores",
-                                    "entity": "this",
-                                    "scores": {
-                                        "selectedItem": -1
-                                    }
-                                }
-                            ],
-                            "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:102b,SpawnSelectionItem:1b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
                         },
                         {
                             "conditions": [
@@ -40,6 +27,19 @@
                             ],
                             "function": "set_nbt",
                             "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "giveSpawnItems": 1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Damage:240}"
                         }
                     ]
                 }

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item3.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item3.json
@@ -10,20 +10,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:103b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
-                        },
-                        {
-                            "conditions": [
-                                {
-                                    "condition": "entity_scores",
-                                    "entity": "this",
-                                    "scores": {
-                                        "selectedItem": -1
-                                    }
-                                }
-                            ],
-                            "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:103b,SpawnSelectionItem:1b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
                         },
                         {
                             "conditions": [
@@ -40,6 +27,19 @@
                             ],
                             "function": "set_nbt",
                             "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "giveSpawnItems": 1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Damage:240}"
                         }
                     ]
                 }

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item3.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item3.json
@@ -26,7 +26,7 @@
                                 }
                             ],
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241,CustomModelData:2}"
                         },
                         {
                             "conditions": [

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item4.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item4.json
@@ -10,20 +10,7 @@
                     "functions": [
                         {
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:104b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
-                        },
-                        {
-                            "conditions": [
-                                {
-                                    "condition": "entity_scores",
-                                    "entity": "this",
-                                    "scores": {
-                                        "selectedItem": -1
-                                    }
-                                }
-                            ],
-                            "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:1b},Damage:240}"
+                            "tag": "{Calamity:{SpawnItem:1b,SpawnItemId:104b,SpawnSelectionItem:1b},CustomModelData:1,Enchantments:[{id:\"minecraft:vanishing_curse\",lvl:10s}]}"
                         },
                         {
                             "conditions": [
@@ -40,6 +27,19 @@
                             ],
                             "function": "set_nbt",
                             "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "condition": "entity_scores",
+                                    "entity": "this",
+                                    "scores": {
+                                        "giveSpawnItems": 1
+                                    }
+                                }
+                            ],
+                            "function": "set_nbt",
+                            "tag": "{Damage:240}"
                         }
                     ]
                 }

--- a/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item4.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/loot_tables/spawn_items/item4.json
@@ -26,7 +26,7 @@
                                 }
                             ],
                             "function": "set_nbt",
-                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241}"
+                            "tag": "{Calamity:{SpawnSelectionItem:0b},Damage:241,CustomModelData:2}"
                         },
                         {
                             "conditions": [


### PR DESCRIPTION
Fixes #26

* Players will now only get the spawn item choice at the beginning and it will remember the selected item.
* If a player dies before selecting an item they will still have a chance of selecting an item.
* Players are no longer able to have a spawn item of a different type in their inventory other than the type they selected.