### PR TITLE
Fixed iron mines flickering

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/load/count_iron_ore.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/load/count_iron_ore.mcfunction
@@ -3,4 +3,4 @@
 #---------------------------------------------------------------------------------------------------
 # Purpose: Count the iron ore and fill it out.
 #---------------------------------------------------------------------------------------------------
-execute store result score OreLeft gameVariable run clone 142 68 182 130 0 194 130 0 182 filtered minecraft:iron_ore move
+execute store result score OreLeft gameVariable run clone 142 68 182 130 0 194 130 0 182 filtered minecraft:iron_ore force

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/points/check_mines_and_update_objective.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/points/check_mines_and_update_objective.mcfunction
@@ -5,7 +5,9 @@
 #---------------------------------------------------------------------------------------------------
 
 # Check out how many iron_ore blocks are in this area and store it
-execute store result score OreLeft gameVariable run clone 142 68 182 130 0 194 130 0 182 filtered minecraft:iron_ore move
+execute store result score OreLeft gameVariable run fill 142 68 182 130 0 194 minecraft:petrified_oak_slab[type=double] replace minecraft:iron_ore
+fill 142 68 182 130 0 194 minecraft:iron_ore replace minecraft:petrified_oak_slab
+
 # Update the bossbar and sidebar
 execute store result bossbar calamity:iron_ore value run scoreboard players get OreLeft gameVariable
 scoreboard players operation Goal displayPoints = OreLeft gameVariable


### PR DESCRIPTION
Bugfix fixes 2 bugs:
* The constant cloning of the iron ores were seemingly making light slip through the ores making dark places in the mines flicker.
* The constant cloning of the iron ores made it impossible to place some blocks on the ores eg buttons

This bugfix uses `/fill` for counting instead of `/clone`. First replacing iron ores with `minecraft:petrified_oak_slab[type=double]` and then instantly replaces the slabs back to iron ore again. This fixes both bugs.

Using `minecraft:petrified_oak_slab[type=double]` as it's the only solid, none tile entity, creative mode only block which the map isn't using already.
