### PR TITLE
Changed item transformations to use loot tables

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
@@ -25,12 +25,6 @@ give @a[tag=RefillItems] minecraft:iron_axe{Damage:240,repairCost:"99999",Enchan
 tag @a remove RefillItems
 
 
-# Convert or kill items as needed
-execute as @e[type=item,nbt={Item:{id:"minecraft:end_stone"}}] run data merge entity @s {Item:{id:"minecraft:cobblestone"}}
-#execute as @e[type=item,nbt={Item:{id:"minecraft:iron_ore"}}] run data merge entity @s {Item:{id:"minecraft:iron_ingot"}}
-kill @e[type=item,nbt={Item:{id:"minecraft:redstone_lamp"}}]
-kill @e[type=item,nbt={Item:{id:"minecraft:prismarine_crystals"}}]
-
 # Feed hungry players, this game isn't about fighting hunger.
 effect give @a[scores={food=..19}] minecraft:saturation 1 0 false
 effect clear @a[scores={food=20}] minecraft:saturation

--- a/saves/calamity/datapacks/calamity/data/minecraft/loot_tables/blocks/end_stone.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/loot_tables/blocks/end_stone.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:cobblestone"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/saves/calamity/datapacks/calamity/data/minecraft/loot_tables/blocks/redstone_lamp.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/loot_tables/blocks/redstone_lamp.json
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:block",
+  "pools": []
+}

--- a/saves/calamity/datapacks/calamity/data/minecraft/loot_tables/blocks/sea_lantern.json
+++ b/saves/calamity/datapacks/calamity/data/minecraft/loot_tables/blocks/sea_lantern.json
@@ -1,0 +1,4 @@
+{
+  "type": "minecraft:block",
+  "pools": []
+}


### PR DESCRIPTION
Bugfix fixes:
* When breaking sea lanterns or redstone lamps their dropped items are visible for a short moment before they are killed.
* When breaking end stone the end stone item is visible for a short amount of time before it's replaced with cobblestone.

This bugfix removes the old `/kill` and `/data` changing commands and instead changes the loot tables of the blocks:
* redstone lamps drops nothing.
* sea lanterns drops nothing.
* end stone drops cobblestone.