### PR TITLE
Count all the iron ores

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/load/count_iron_ore.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/load/count_iron_ore.mcfunction
@@ -3,4 +3,4 @@
 #---------------------------------------------------------------------------------------------------
 # Purpose: Count the iron ore and fill it out.
 #---------------------------------------------------------------------------------------------------
-execute store result score OreLeft gameVariable run clone 142 68 182 130 0 194 130 0 182 filtered minecraft:iron_ore force
+execute store result score OreLeft gameVariable run clone 142 67 181 130 0 195 130 0 181 filtered minecraft:iron_ore force

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/points/check_mines_and_update_objective.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/points/check_mines_and_update_objective.mcfunction
@@ -5,8 +5,8 @@
 #---------------------------------------------------------------------------------------------------
 
 # Check out how many iron_ore blocks are in this area and store it
-execute store result score OreLeft gameVariable run fill 142 68 182 130 0 194 minecraft:petrified_oak_slab[type=double] replace minecraft:iron_ore
-fill 142 68 182 130 0 194 minecraft:iron_ore replace minecraft:petrified_oak_slab
+execute store result score OreLeft gameVariable run fill 142 67 181 130 0 195 minecraft:petrified_oak_slab[type=double] replace minecraft:iron_ore
+fill 142 67 181 130 0 195 minecraft:iron_ore replace minecraft:petrified_oak_slab
 
 # Update the bossbar and sidebar
 execute store result bossbar calamity:iron_ore value run scoreboard players get OreLeft gameVariable


### PR DESCRIPTION
Some iron ores in the iron mine aren't being counted.

This bugfix fixes it and counts all the ores.

Extra info: right now there is 397 iron ores. It would be nice if there was 3 more.