### PR TITLE
Made spawn items only be given to alive players

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/load/setup_scoreboards.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/load/setup_scoreboards.mcfunction
@@ -40,6 +40,8 @@ scoreboard objectives remove SuccessCount
 scoreboard objectives add SuccessCount dummy
 scoreboard objectives remove loggedOff
 scoreboard objectives add loggedOff minecraft.custom:minecraft.leave_game
+scoreboard objectives remove timeSinceDeath
+scoreboard objectives add timeSinceDeath minecraft.custom:minecraft.time_since_death
 
 scoreboard objectives remove PointTimer
 scoreboard objectives add PointTimer dummy

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
@@ -32,5 +32,4 @@ execute if entity @s[tag=GiveSelectedStartingItem] run function calamity:player/
 tag @s[tag=GiveSelectedStartingItem] remove GiveSelectedStartingItem
 
 # On death give selection items after a little time
-execute if entity @s[scores={giveSpawnItems=1..}] run scoreboard players add @s giveSpawnItems 1
-execute if entity @s[scores={giveSpawnItems=5..}] run function calamity:player/spawn_items/give_items
+execute if entity @s[scores={giveSpawnItems=1..,timeSinceDeath=1..}] run function calamity:player/spawn_items/give_items


### PR DESCRIPTION
This will hopefully fix the spawn item bug 100% this time.
Last time I tried to fix this problem by adding some delay to the item giving which seemed to help. Sadly some players still seemed to be running into problems with not getting the item.

After some thinking I have concluded that `/gamerule doImmediateRespawn true` actually isn't "immediate".
It seems like when the player dies they will first respawn after the server has send to the client that it has died and the client sends back to the server that it wants to respawn. (So when immediate respawn is true its like if the player instantly presses the respawn button when they die). If players have bad ping (or are lagging) then the respawning will take longer time than normal and they will get the items while being dead (And wont keep them when they respawn).

I have now made it so it checks if the player actually is alive before giving them the spawn items.
This is done using the scoreboard objective `minecraft.custom:minecraft.time_since_death` which only goes up when the player is alive.


I really hope it will work correctly this time.