### PR TITLE
Players can die the moment the game starts if they're in the air in the lobby

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/timer_start_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/timer_start_match.mcfunction
@@ -21,6 +21,9 @@ execute if score TimeInTicks gameVariable matches 80 run tellraw @a {"translate"
 execute if score TimeInTicks gameVariable matches 60 run tellraw @a {"translate":"%s %s...","color":"green","with":[{"text":">>>","color":"white"},{"score":{"name":"#InSeconds","objective":"gameVariable"},"color":"white"}]}
 execute if score TimeInTicks gameVariable matches 40 run tellraw @a {"translate":"%s %s...","color":"green","with":[{"text":">>>","color":"white"},{"score":{"name":"#InSeconds","objective":"gameVariable"},"color":"white"}]}
 execute if score TimeInTicks gameVariable matches 20 run tellraw @a {"translate":"%s %s...","color":"green","with":[{"text":">>>","color":"white"},{"score":{"name":"#InSeconds","objective":"gameVariable"},"color":"white"}]}
+# Reset fall damage for everyone, so players that are currently falling won't die after the game has started
+execute if score TimeInTicks gameVariable matches 1 run effect give @a minecraft:slow_falling 1 0 true
+execute if score TimeInTicks gameVariable matches 0 run effect clear @a minecraft:slow_falling
 # It's time to start the game!
 execute if score TimeInTicks gameVariable matches 0 run function calamity:game_state/start_match
 


### PR DESCRIPTION
Players can die by fall damage the moment the game starts if they're in the air in the lobby.
This adds slow falling to players for a single tick to cancel their fall damage to stop this from happening.

![image](https://user-images.githubusercontent.com/24660095/110393641-342aac80-806b-11eb-86a9-009dd83fe2c1.png)
