### PR TITLE
Bugfix/out of bounds

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/advancements/build_protection/detect_block_under_barrier.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/advancements/build_protection/detect_block_under_barrier.json
@@ -1,0 +1,35 @@
+{
+    "comment": "Advancment used for detecting if the player places a block on a barrier block",
+    "parent": "calamity:spawn_items/hidden_root",
+    "rewards": {
+        "function": "calamity:build_protection/outside_blocks/detect_bad_blocks"
+    },
+    "criteria": {
+        "placed_maybe_bad_block": {
+            "trigger": "minecraft:item_used_on_block",
+            "conditions": {
+                "location": {
+                    "block": {
+                        "block": "minecraft:barrier"
+                    },
+                    "position": {
+                        "y": {
+                            "min": 67,
+                            "max": 69
+                        }
+                    }
+                },
+                "player": {
+                    "player": {
+                        "gamemode": "survival"
+                    }
+                }
+            }
+        }
+    },
+    "requirements": [
+        [
+            "placed_maybe_bad_block"
+        ]
+    ]
+}

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/handler.mcfunction
@@ -23,6 +23,7 @@
 # We summon a marker entity at tnt which is about to explode so we can use the tnt's location after it has blown up.
 execute as @e[tag=ExplosionMarker] at @s run function calamity:build_protection/handle_explosion
 execute as @e[type=tnt,nbt={Fuse:1s}] at @s run summon minecraft:area_effect_cloud ~ ~ ~ {Duration:2,Tags:["ExplosionMarker"]}
+execute as @e[type=tnt,nbt={Fuse:1s}] at @s run fill ~5 68 ~5 ~-5 68 ~-5 minecraft:barrier
 
 # Also have to fix the protection if it was blown up by a bed.
 # There is no real way to detect if a bed explosion so we have changed bed loot tables to drop a nether star when broken.

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks.mcfunction
@@ -1,0 +1,8 @@
+# called from the advancement calamity:build_protection/detect_block_under_barrier
+
+advancement revoke @s only calamity:build_protection/detect_block_under_barrier
+
+execute if entity @s[tag=Playing] positioned ~-12 67 ~-12 run function calamity:build_protection/outside_blocks/detect_bad_blocks_12
+execute if entity @s[tag=Playing] positioned ~-12 67 ~ run function calamity:build_protection/outside_blocks/detect_bad_blocks_12
+execute if entity @s[tag=Playing] positioned ~ 67 ~-12 run function calamity:build_protection/outside_blocks/detect_bad_blocks_12
+execute if entity @s[tag=Playing] positioned ~ 67 ~ run function calamity:build_protection/outside_blocks/detect_bad_blocks_12

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks_12.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks_12.mcfunction
@@ -1,0 +1,6 @@
+# called by calamity:build_protection/outside_blocks/detect_bad_blocks
+
+execute positioned ~ ~ ~ run function calamity:build_protection/outside_blocks/detect_bad_blocks_6
+execute positioned ~6 ~ ~ run function calamity:build_protection/outside_blocks/detect_bad_blocks_6
+execute positioned ~ ~ ~6 run function calamity:build_protection/outside_blocks/detect_bad_blocks_6
+execute positioned ~6 ~ ~6 run function calamity:build_protection/outside_blocks/detect_bad_blocks_6

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks_3.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks_3.mcfunction
@@ -1,0 +1,11 @@
+# called by calamity:build_protection/outside_blocks/detect_bad_blocks_16
+
+execute positioned ~ ~ ~ if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~1 ~ ~ if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~2 ~ ~ if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~ ~ ~1 if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~1 ~ ~1 if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~2 ~ ~1 if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~ ~ ~2 if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~1 ~ ~2 if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~2 ~ ~2 if block ~ ~2 ~ minecraft:air unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks_6.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/detect_bad_blocks_6.mcfunction
@@ -1,0 +1,6 @@
+# called by calamity:build_protection/outside_blocks/detect_bad_blocks_12
+
+execute positioned ~ ~ ~ run function calamity:build_protection/outside_blocks/detect_bad_blocks_3
+execute positioned ~3 ~ ~ run function calamity:build_protection/outside_blocks/detect_bad_blocks_3
+execute positioned ~ ~ ~3 run function calamity:build_protection/outside_blocks/detect_bad_blocks_3
+execute positioned ~3 ~ ~3 run function calamity:build_protection/outside_blocks/detect_bad_blocks_3

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/remove_bad_block.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/outside_blocks/remove_bad_block.mcfunction
@@ -1,0 +1,10 @@
+# called by calamity:build_protection/outside_blocks/detect_bad_blocks_3
+
+setblock ~ ~ ~ air destroy
+
+execute positioned ~1 ~ ~ unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~-1 ~ ~ unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~ ~1 ~ unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~ ~-1 ~ unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~ ~ ~1 unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block
+execute positioned ~ ~ ~-1 unless block ~ ~ ~ #calamity:valid_outside run function calamity:build_protection/outside_blocks/remove_bad_block

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
@@ -11,3 +11,5 @@ title @s times 0 2 1
 title @s subtitle {"translate": "Out of bounds!","color":"red"} 
 title @s title {"translate": ""} 
 gamemode adventure @s[gamemode=survival]
+
+execute if block ~-1 69 ~-1 #calamity:out_of_bounds_block if block ~1 69 ~-1 #calamity:out_of_bounds_block if block ~1 69 ~1 #calamity:out_of_bounds_block if block ~-1 69 ~1 #calamity:out_of_bounds_block if block ~-1 69 ~ #calamity:out_of_bounds_block if block ~1 69 ~ #calamity:out_of_bounds_block if block ~ 69 ~1 #calamity:out_of_bounds_block if block ~ 69 ~-1 #calamity:out_of_bounds_block unless @e[type=boat,distance=..2] run kill @s[nbt={OnGround:1b}]

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
@@ -12,4 +12,4 @@ title @s subtitle {"translate": "Out of bounds!","color":"red"}
 title @s title {"translate": ""} 
 gamemode adventure @s[gamemode=survival]
 
-execute if block ~-1 69 ~-1 #calamity:out_of_bounds_block if block ~1 69 ~-1 #calamity:out_of_bounds_block if block ~1 69 ~1 #calamity:out_of_bounds_block if block ~-1 69 ~1 #calamity:out_of_bounds_block if block ~-1 69 ~ #calamity:out_of_bounds_block if block ~1 69 ~ #calamity:out_of_bounds_block if block ~ 69 ~1 #calamity:out_of_bounds_block if block ~ 69 ~-1 #calamity:out_of_bounds_block unless @e[type=boat,distance=..2] run kill @s[nbt={OnGround:1b}]
+execute if block ~-1 69 ~-1 #calamity:out_of_bounds_block if block ~1 69 ~-1 #calamity:out_of_bounds_block if block ~1 69 ~1 #calamity:out_of_bounds_block if block ~-1 69 ~1 #calamity:out_of_bounds_block if block ~-1 69 ~ #calamity:out_of_bounds_block if block ~1 69 ~ #calamity:out_of_bounds_block if block ~ 69 ~1 #calamity:out_of_bounds_block if block ~ 69 ~-1 #calamity:out_of_bounds_block unless entity @e[type=boat,distance=..2] run kill @s[nbt={OnGround:1b}]

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
@@ -10,3 +10,4 @@ effect give @s minecraft:mining_fatigue 1 7
 title @s times 0 2 1
 title @s subtitle {"translate": "Out of bounds!","color":"red"} 
 title @s title {"translate": ""} 
+gamemode adventure @s[gamemode=survival]

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
@@ -21,9 +21,10 @@ effect give @a[scores={food=..19}] minecraft:saturation 1 0 false
 effect clear @a[scores={food=20}] minecraft:saturation
 
 # Kill players who are out of bounds
-execute as @a[tag=Playing,gamemode=survival] at @s if block ~ 69 ~ #calamity:out_of_bounds_block run function calamity:player/out_of_bounds
-execute as @a[tag=Playing,gamemode=survival] at @s if block 96 ~ 86 minecraft:barrier run tellraw @s {"text":"You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference.","color": "gray","italic": true}
-execute as @a[tag=Playing,gamemode=survival] at @s if block 96 ~ 86 minecraft:barrier run kill @s
+execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block ~ 69 ~ #calamity:out_of_bounds_block run function calamity:player/out_of_bounds
+execute as @a[tag=Playing,gamemode=adventure] at @s unless block ~ 69 ~ #calamity:out_of_bounds_block run gamemode survival @s
+execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block 96 ~ 86 minecraft:barrier run tellraw @s {"text":"You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference.","color": "gray","italic": true}
+execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block 96 ~ 86 minecraft:barrier run kill @s
 
 # Kill out of bounds boats
 execute as @e[type=boat] at @s if block ~ 69 ~ #calamity:out_of_bounds_block run kill @s

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
@@ -23,8 +23,8 @@ effect clear @a[scores={food=20}] minecraft:saturation
 # Kill players who are out of bounds
 execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block ~ 69 ~ #calamity:out_of_bounds_block run function calamity:player/out_of_bounds
 execute as @a[tag=Playing,gamemode=adventure] at @s unless block ~ 69 ~ #calamity:out_of_bounds_block run gamemode survival @s
-execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block 96 ~ 86 minecraft:barrier run tellraw @s {"text":"You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference.","color": "gray","italic": true}
-execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block 96 ~ 86 minecraft:barrier run kill @s
+execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block 96 ~1 86 minecraft:barrier run tellraw @s {"text":"You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference.","color": "gray","italic": true}
+execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s if block 96 ~1 86 minecraft:barrier run kill @s
 
 # Kill out of bounds boats
 execute as @e[type=boat] at @s if block ~ 69 ~ #calamity:out_of_bounds_block run kill @s

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/tick.mcfunction
@@ -25,6 +25,9 @@ execute as @a[tag=Playing,gamemode=survival] at @s if block ~ 69 ~ #calamity:out
 execute as @a[tag=Playing,gamemode=survival] at @s if block 96 ~ 86 minecraft:barrier run tellraw @s {"text":"You cheated not only the game, but yourself. You didn't grow. You didn't improve. You took a shortcut and gained nothing. You experienced a hollow victory. Nothing was risked and nothing was gained. It's sad that you don't know the difference.","color": "gray","italic": true}
 execute as @a[tag=Playing,gamemode=survival] at @s if block 96 ~ 86 minecraft:barrier run kill @s
 
+# Kill out of bounds boats
+execute as @e[type=boat] at @s if block ~ 69 ~ #calamity:out_of_bounds_block run kill @s
+
 # Highlight players who fell in this location.
 execute as @a[gamemode=adventure,x=135,y=54,z=59,dx=2,dz=2,tag=!HowEmbarassing] run tag @s add HowEmbarassing
 execute as @a[tag=HowEmbarassing,tag=!MessageSent] run tellraw @a {"translate":"%s fell in the troll hole! How embarassing!","with": [{"selector":"@s"}]}

--- a/saves/calamity/datapacks/calamity/data/calamity/tags/blocks/valid_outside.json
+++ b/saves/calamity/datapacks/calamity/data/calamity/tags/blocks/valid_outside.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "minecraft:barrier",
+      "minecraft:moving_piston",
+      "minecraft:air"
+    ]
+}


### PR DESCRIPTION
Fixes a few possible ways of abusing out of bounds:
* I finally found out after almost 2 months that it's possible to place blocks outside the map by placing blocks below the barrier blocks out of bounds. This is no longer possible (Blocks will be broken)
* It was possible to blow up the outer layer of yellow stained glass by shooting a tnt out next to it. Fix is to place barrier blocks above tnt at layer 68.
* Players could make boat bridges out of bounds and it was also possible to go from red to blue side using correctly placed boats. Out of bounds boats are now killed to fix this.
* Out of bounds players will be set to adventure mode (so its even harder for them to do harm)
* Out of bounds players who are fully out of bounds (no in bounds blocks nearby) and standing on something will be killed. There is a small check making sure that players standing on boats wont die. This is to stop players from dying if they stand on a boat which is just at the edge of out of bounds. (It shouldn't be possible to cheese this boat thing as boats out of bounds are killed)
* Players with their head in or above the barrier layer will now be killed.

With all of these changes the only possible abuseable thing I'm seeing is that by lag switching its most likely possible to place blocks on the yellow stained glass at the edges (and thereby place chests out of bounds which aren't cleared on reset allowing players to keep items through games). The fix for this would be to extend the barrier layer a few blocks out on the sides. I haven't done this as I'm scared of touching the structure files and region files. I would suggest someone to extend the barriers.
