### PR TITLE
Feature/reset spawn item

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/end_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/end_match.mcfunction
@@ -15,12 +15,16 @@ execute store result score SessionID gameVariable run time query gametime
 scoreboard players operation @a sessionID = SessionID gameVariable
 
 # Update player triggers
+scoreboard players reset @a resetSpawnItem
 scoreboard players reset @a gg
 scoreboard players reset @a reset
 scoreboard players enable @a reset
 
 # Remove forfeit tag
 tag @a remove VotedForfeit
+
+# Remove reset items tag in case they have it
+tag @a remove ResetTheSpawnItem
 
 # Allow players to reset the map themselves
 tellraw @a {"translate":"Thanks for playing! Use [%s] to play again.","color":"green","with":[{"text":"/trigger reset","color":"white","clickEvent":{"action":"suggest_command","value":"/trigger reset"},"hoverEvent":{"action":"show_text","value":"Click here to send the command to your text box."}}]}

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/load/setup_scoreboards.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/load/setup_scoreboards.mcfunction
@@ -119,6 +119,9 @@ scoreboard objectives add reset trigger
     # Let teams ready up
     scoreboard objectives remove readyTeam
     scoreboard objectives add readyTeam trigger
+    # Resets your chosen starting weapon
+    scoreboard objectives remove resetSpawnItem
+    scoreboard objectives add resetSpawnItem trigger
 
 # Craft items are worth points. This scoreboard tracks those points.
 # iron_nugget and iron_block have been intentionally left out.

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
@@ -5,7 +5,6 @@
 execute if entity @s[tag=ResetTheSpawnItem] run scoreboard players set @s selectedItem -1
 execute if entity @s[tag=ResetTheSpawnItem] run tag @s remove ResetTheSpawnItem
 
-
 # Revoke spawn item advancements both to clean up, but also to allow players to have spawn items again 
 advancement revoke @s from calamity:spawn_items/hidden_root
 advancement grant @s only calamity:spawn_items/hidden_root

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/give_items.mcfunction
@@ -1,6 +1,11 @@
 # Called form calamity:player/spawn_items/handler
 # (Called after player has died)
 
+# Clear player's selected item choice if they have chosen so
+execute if entity @s[tag=ResetTheSpawnItem] run scoreboard players set @s selectedItem -1
+execute if entity @s[tag=ResetTheSpawnItem] run tag @s remove ResetTheSpawnItem
+
+
 # Revoke spawn item advancements both to clean up, but also to allow players to have spawn items again 
 advancement revoke @s from calamity:spawn_items/hidden_root
 advancement grant @s only calamity:spawn_items/hidden_root

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/handler.mcfunction
@@ -33,3 +33,6 @@ tag @s[tag=GiveSelectedStartingItem] remove GiveSelectedStartingItem
 
 # On death give selection items after a little time
 execute if entity @s[scores={giveSpawnItems=1..,timeSinceDeath=1..}] run function calamity:player/spawn_items/give_items
+
+execute unless score @s resetSpawnItem matches 0 run function calamity:player/spawn_items/reset_item_trigger
+scoreboard players enable @s resetSpawnItem

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/reset_item_trigger.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/spawn_items/reset_item_trigger.mcfunction
@@ -1,0 +1,5 @@
+scoreboard players set @s resetSpawnItem 0
+tellraw @s[tag=ResetTheSpawnItem] {"translate":">>> You have already chosen to reset your item next time you respawn."}
+execute unless score @s selectedItem matches -1 run tellraw @s[tag=!ResetTheSpawnItem] {"translate":">>> You will get to select a new item the next time you respawn."}
+execute unless score @s selectedItem matches -1 run tag @s add ResetTheSpawnItem
+execute if score @s selectedItem matches -1 run tellraw @s[tag=!ResetTheSpawnItem] {"translate":">>> You haven't selected an item yet. Nothing to reset."}


### PR DESCRIPTION
Allows players to reset their spawn item with the trigger `resetSpawnItem`. The next time the player respawns after using the trigger they will get the tool selection.