### PR TITLE
soft out of bounds

### DIFF
--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/handle_explosion.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/handle_explosion.mcfunction
@@ -36,6 +36,7 @@ execute if score #tempHeight gameVariable > 8 CONST run function calamity:build_
 
 # Reset our temp variables
 scoreboard players reset #tempVar gameVariable
+scoreboard players reset #tempVar2 gameVariable
 scoreboard players reset #tempHeight gameVariable
 scoreboard players reset #tempYLocation gameVariable
 

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_large.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_large.mcfunction
@@ -4,14 +4,14 @@
 #> Purpose: Check if there are blocks and split into the small sections
 #>--------------------------------------------------------------------------------------------------
 
-execute store result score #tempVar gameVariable run fill ~-12 254 ~-12 ~-1 254 ~-1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-12 250 ~-12 ~-1 250 ~-1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_medium
 
-execute store result score #tempVar gameVariable run fill ~-12 254 ~0 ~-1 254 ~11 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-12 250 ~0 ~-1 250 ~11 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~6 run function calamity:build_protection/search/section_medium
 
-execute store result score #tempVar gameVariable run fill ~0 254 ~-12 ~11 254 ~-1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~0 250 ~-12 ~11 250 ~-1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~6 ~ ~-6 run function calamity:build_protection/search/section_medium
 
-execute store result score #tempVar gameVariable run fill ~0 254 ~0 ~11 254 ~11 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~0 250 ~0 ~11 250 ~11 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~6 ~ ~6 run function calamity:build_protection/search/section_medium

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_large_all.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_large_all.mcfunction
@@ -4,14 +4,21 @@
 #> Purpose: Check if there are blocks and split into the small sections
 #>--------------------------------------------------------------------------------------------------
 
-execute store result score #tempVar gameVariable run fill ~-12 254 ~-12 ~-1 255 ~-1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-12 255 ~-12 ~-1 255 ~-1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-12 250 ~-12 ~-1 250 ~-1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_medium_all
 
-execute store result score #tempVar gameVariable run fill ~-12 254 ~0 ~-1 255 ~11 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-12 255 ~0 ~-1 255 ~11 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-12 250 ~0 ~-1 250 ~11 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~6 run function calamity:build_protection/search/section_medium_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar2 gameVariable matches 0 positioned ~-6 ~ ~6 run function calamity:build_protection/search/section_medium
 
-execute store result score #tempVar gameVariable run fill ~0 254 ~-12 ~11 255 ~-1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~0 255 ~-12 ~11 255 ~-1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~0 250 ~-12 ~11 250 ~-1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~6 ~ ~-6 run function calamity:build_protection/search/section_medium_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar2 gameVariable matches 0 positioned ~6 ~ ~-6 run function calamity:build_protection/search/section_medium
 
-execute store result score #tempVar gameVariable run fill ~0 254 ~0 ~11 255 ~11 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~0 255 ~0 ~11 255 ~11 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~0 250 ~0 ~11 250 ~11 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~6 ~ ~6 run function calamity:build_protection/search/section_medium_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar2 gameVariable matches 0 positioned ~6 ~ ~6 run function calamity:build_protection/search/section_medium

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_large_all.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_large_all.mcfunction
@@ -7,18 +7,19 @@
 execute store result score #tempVar gameVariable run fill ~-12 255 ~-12 ~-1 255 ~-1 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-12 250 ~-12 ~-1 250 ~-1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_medium_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_medium
 
 execute store result score #tempVar gameVariable run fill ~-12 255 ~0 ~-1 255 ~11 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-12 250 ~0 ~-1 250 ~11 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~6 run function calamity:build_protection/search/section_medium_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar2 gameVariable matches 0 positioned ~-6 ~ ~6 run function calamity:build_protection/search/section_medium
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-6 ~ ~6 run function calamity:build_protection/search/section_medium
 
 execute store result score #tempVar gameVariable run fill ~0 255 ~-12 ~11 255 ~-1 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~0 250 ~-12 ~11 250 ~-1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~6 ~ ~-6 run function calamity:build_protection/search/section_medium_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar2 gameVariable matches 0 positioned ~6 ~ ~-6 run function calamity:build_protection/search/section_medium
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~6 ~ ~-6 run function calamity:build_protection/search/section_medium
 
 execute store result score #tempVar gameVariable run fill ~0 255 ~0 ~11 255 ~11 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~0 250 ~0 ~11 250 ~11 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~6 ~ ~6 run function calamity:build_protection/search/section_medium_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar2 gameVariable matches 0 positioned ~6 ~ ~6 run function calamity:build_protection/search/section_medium
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~6 ~ ~6 run function calamity:build_protection/search/section_medium

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_medium.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_medium.mcfunction
@@ -1,32 +1,32 @@
 # Called from: calamity:build_protection/search/section_large
 
 # Put the replaced barrier blocks back
-fill ~-6 254 ~-6 ~5 254 ~5 minecraft:barrier replace minecraft:glass
+fill ~-6 250 ~-6 ~5 250 ~5 minecraft:barrier replace minecraft:glass
 
 # Do the split into 4x4 sections.
-execute store result score #tempVar gameVariable run fill ~-6 254 ~-6 ~-3 254 ~-3 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-6 250 ~-6 ~-3 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~-6 254 ~-2 ~-3 254 ~1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-6 250 ~-2 ~-3 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-2 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~-2 254 ~-6 ~1 254 ~-3 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-2 250 ~-6 ~1 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~-6 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~-2 254 ~-2 ~1 254 ~1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-2 250 ~-2 ~1 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~-2 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~-6 254 ~2 ~-3 254 ~5 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-6 250 ~2 ~-3 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~2 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~2 254 ~-6 ~5 254 ~-3 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~2 250 ~-6 ~5 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~-6 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~-2 254 ~2 ~1 254 ~5 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~-2 250 ~2 ~1 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~2 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~2 254 ~-2 ~5 254 ~1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~2 250 ~-2 ~5 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~-2 run function calamity:build_protection/search/section_small
 
-execute store result score #tempVar gameVariable run fill ~2 254 ~2 ~5 254 ~5 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar gameVariable run fill ~2 250 ~2 ~5 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~2 run function calamity:build_protection/search/section_small

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_medium_all.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_medium_all.mcfunction
@@ -2,31 +2,51 @@
 
 # Put the replaced barrier blocks back
 fill ~-6 254 ~-6 ~5 255 ~5 minecraft:barrier replace minecraft:glass
+fill ~-6 250 ~-6 ~5 250 ~5 minecraft:barrier replace minecraft:glass
+
 
 # Do the split into 4x4 sections.
 execute store result score #tempVar gameVariable run fill ~-6 254 ~-6 ~-3 255 ~-3 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-6 250 ~-6 ~-3 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-6 254 ~-2 ~-3 255 ~1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-6 250 ~-2 ~-3 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-2 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-6 ~ ~-2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-2 254 ~-6 ~1 255 ~-3 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-2 250 ~-6 ~1 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~-6 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-2 ~ ~-6 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-2 254 ~-2 ~1 255 ~1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-2 250 ~-2 ~1 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~-2 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-2 ~ ~-2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-6 254 ~2 ~-3 255 ~5 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-6 250 ~2 ~-3 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~2 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-6 ~ ~2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~2 254 ~-6 ~5 255 ~-3 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~2 250 ~-6 ~5 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~-6 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~2 ~ ~-6 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-2 254 ~2 ~1 255 ~5 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~-2 250 ~2 ~1 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~2 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-2 ~ ~2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~2 254 ~-2 ~5 255 ~1 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~2 250 ~-2 ~5 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~-2 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~2 ~ ~-2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~2 254 ~2 ~5 255 ~5 minecraft:glass replace minecraft:barrier
+execute store result score #tempVar2 gameVariable run fill ~2 250 ~2 ~5 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~2 run function calamity:build_protection/search/section_small_all
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~2 ~ ~2 run function calamity:build_protection/search/section_small

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_medium_all.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_medium_all.mcfunction
@@ -9,44 +9,44 @@ fill ~-6 250 ~-6 ~5 250 ~5 minecraft:barrier replace minecraft:glass
 execute store result score #tempVar gameVariable run fill ~-6 254 ~-6 ~-3 255 ~-3 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-6 250 ~-6 ~-3 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-6 ~ ~-6 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-6 254 ~-2 ~-3 255 ~1 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-6 250 ~-2 ~-3 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~-2 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-6 ~ ~-2 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-6 ~ ~-2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-2 254 ~-6 ~1 255 ~-3 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-2 250 ~-6 ~1 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~-6 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-2 ~ ~-6 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-2 ~ ~-6 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-2 254 ~-2 ~1 255 ~1 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-2 250 ~-2 ~1 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~-2 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-2 ~ ~-2 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-2 ~ ~-2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-6 254 ~2 ~-3 255 ~5 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-6 250 ~2 ~-3 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-6 ~ ~2 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-6 ~ ~2 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-6 ~ ~2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~2 254 ~-6 ~5 255 ~-3 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~2 250 ~-6 ~5 250 ~-3 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~-6 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~2 ~ ~-6 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~2 ~ ~-6 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~-2 254 ~2 ~1 255 ~5 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~-2 250 ~2 ~1 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~-2 ~ ~2 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~-2 ~ ~2 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~-2 ~ ~2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~2 254 ~-2 ~5 255 ~1 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~2 250 ~-2 ~5 250 ~1 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~-2 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~2 ~ ~-2 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~2 ~ ~-2 run function calamity:build_protection/search/section_small
 
 execute store result score #tempVar gameVariable run fill ~2 254 ~2 ~5 255 ~5 minecraft:glass replace minecraft:barrier
 execute store result score #tempVar2 gameVariable run fill ~2 250 ~2 ~5 250 ~5 minecraft:glass replace minecraft:barrier
 execute if score #tempVar gameVariable matches 1.. positioned ~2 ~ ~2 run function calamity:build_protection/search/section_small_all
-execute if score #tempVar2 gameVariable matches 1.. if score #tempVar matches 0 positioned ~2 ~ ~2 run function calamity:build_protection/search/section_small
+execute if score #tempVar2 gameVariable matches 1.. if score #tempVar gameVariable matches 0 positioned ~2 ~ ~2 run function calamity:build_protection/search/section_small

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_small.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_small.mcfunction
@@ -1,22 +1,22 @@
 # Called from: calamity:build_protection/search/section_medium
 
 # Put the replaced barrier blocks back
-fill ~ 254 ~ ~3 254 ~3 minecraft:barrier replace minecraft:glass
+fill ~ 250 ~ ~3 250 ~3 minecraft:barrier replace minecraft:glass
 
 # Check if there is supposed to be a moving_piston wall and fix the wall
-execute positioned ~0 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~0 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~0 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~0 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_small_all.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/build_protection/search/section_small_all.mcfunction
@@ -1,25 +1,26 @@
 # Called from: calamity:build_protection/search/section_medium_all
 
 # Put the replaced barrier blocks back
-fill ~ 254 ~ ~3 255 ~3 minecraft:barrier replace minecraft:glass
+fill ~ 255 ~ ~3 255 ~3 minecraft:barrier replace minecraft:glass
+fill ~ 250 ~ ~3 250 ~3 minecraft:barrier replace minecraft:glass
 
 # Check if there is supposed to be a moving_piston wall and fix the wall
-execute positioned ~0 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~0 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~0 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~1 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~0 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~2 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~0 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~1 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~2 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
-execute positioned ~3 ~ ~3 if block ~ 254 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~0 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~1 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~2 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~0 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~1 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~2 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
+execute positioned ~3 ~ ~3 if block ~ 250 ~ minecraft:barrier run function calamity:build_protection/fix_wall
 
 # Check if there is supposed to be a moving_piston height roof and fix the height roof  
 execute positioned ~0 ~ ~0 if block ~ 255 ~ minecraft:barrier run function calamity:build_protection/fix_height

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/tick_match.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/game_state/tick_match.mcfunction
@@ -19,7 +19,7 @@ function calamity:arena/handler
 # Kill players who are out of bounds
 execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] store result score @s playerHeight run data get entity @s Pos[1]
 execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] run scoreboard players operation @s playerHeight -= 2 CONST
-execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s unless block ~ 255 ~0.31 minecraft:barrier unless block ~ 255 ~-0.31 minecraft:barrier unless block ~0.31 255 ~ minecraft:barrier unless block ~-0.31 255 ~ minecraft:barrier run function calamity:player/out_of_bounds
+execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] at @s unless block ~-0.3 255 ~-0.3 minecraft:barrier unless block ~0.3 255 ~0.3 minecraft:barrier unless block ~-0.3 255 ~0.3 minecraft:barrier unless block ~0.3 255 ~-0.3 minecraft:barrier unless block ~ 255 ~0.3 minecraft:barrier unless block ~ 255 ~-0.3 minecraft:barrier unless block ~0.3 255 ~ minecraft:barrier unless block ~-0.3 255 ~ minecraft:barrier run function calamity:player/out_of_bounds
 execute as @a[tag=Playing,gamemode=!spectator,gamemode=!creative] unless score @s playerHeight < #arenaHeight gameVariable run function calamity:player/out_of_bounds
 execute as @a[tag=Playing,gamemode=adventure] at @s if block ~ 255 ~ minecraft:barrier run gamemode survival @s
 

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
@@ -7,7 +7,7 @@
 # Players not in bounds need a show and tell session.
 # Also make sure they can not commit any actions.
 effect give @s minecraft:weakness 1 7
-effect give @s minecraft:slowness 1 7
+effect give @s minecraft:slowness 1 2
 title @s times 0 2 1
 title @s subtitle {"translate": "calamity.out.of.bounds","color":"red"} 
 title @s title {"text": ""} 

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
@@ -7,7 +7,6 @@
 # Players not in bounds need a show and tell session.
 # Also make sure they can not commit any actions.
 effect give @s minecraft:weakness 1 7
-effect give @s minecraft:mining_fatigue 1 7
 effect give @s minecraft:slowness 1 7
 title @s times 0 2 1
 title @s subtitle {"translate": "calamity.out.of.bounds","color":"red"} 

--- a/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
+++ b/saves/calamity/datapacks/calamity/data/calamity/functions/player/out_of_bounds.mcfunction
@@ -4,8 +4,8 @@
 #> Purpose: A player has gone out of bounds, let's punish them a bit for it.
 #>--------------------------------------------------------------------------------------------------
 
-# Kill players who are in the void. We don't actually care of they stare into the void. We're only
-#   slightly concerned about what stares back. Don't think about it. Don't think about it.
+# Players not in bounds need a show and tell session.
+# Also make sure they can not commit any actions.
 effect give @s minecraft:weakness 1 7
 effect give @s minecraft:mining_fatigue 1 7
 effect give @s minecraft:slowness 1 7
@@ -13,10 +13,8 @@ title @s times 0 2 1
 title @s subtitle {"translate": "calamity.out.of.bounds","color":"red"} 
 title @s title {"text": ""} 
 gamemode adventure @s[gamemode=survival]
-# Unless, unless, unless, unless you're out of bounds...you're going to be alright. Unless.
-execute unless block ~-1 255 ~-1 minecraft:barrier unless block ~1 255 ~-1 minecraft:barrier unless block ~1 255 ~1 minecraft:barrier unless block ~-1 255 ~1 minecraft:barrier unless block ~-1 255 ~ minecraft:barrier unless block ~1 255 ~ minecraft:barrier unless block ~ 255 ~1 minecraft:barrier unless block ~ 255 ~-1 minecraft:barrier unless entity @e[type=boat,distance=..2] run kill @s[nbt={OnGround: 1b}]
 
-# If a player somehow did the impossible and placed a block out of bounds, let's send them the most
-#   ridiculous message we can think of.
-execute unless block ~-1 254 ~-1 minecraft:barrier unless block ~1 254 ~-1 minecraft:barrier unless block ~1 254 ~1 minecraft:barrier unless block ~-1 254 ~1 minecraft:barrier unless block ~-1 254 ~ minecraft:barrier unless block ~1 254 ~ minecraft:barrier unless block ~ 254 ~1 minecraft:barrier unless block ~ 254 ~-1 minecraft:barrier run tellraw @s[tag=Playing,gamemode=!spectator,gamemode=!creative,nbt={OnGround:1b}] {"translate":"calamity.cheated.yourself","color": "gray","italic": true}
-execute unless block ~-1 254 ~-1 minecraft:barrier unless block ~1 254 ~-1 minecraft:barrier unless block ~1 254 ~1 minecraft:barrier unless block ~-1 254 ~1 minecraft:barrier unless block ~-1 254 ~ minecraft:barrier unless block ~1 254 ~ minecraft:barrier unless block ~ 254 ~1 minecraft:barrier unless block ~ 254 ~-1 minecraft:barrier run kill @s[tag=Playing,gamemode=!spectator,gamemode=!creative,nbt={OnGround:1b}]
+# "Soft out of bounds" is determined by a barrier data layer at y=254. They are allowed to continue to live.
+# If a player is not in the "soft out of bounds" area then they can be killed if they touch the ground again.
+execute unless block ~-0.3 254 ~-0.3 minecraft:barrier unless block ~0.3 254 ~-0.3 minecraft:barrier unless block ~0.3 254 ~0.3 minecraft:barrier unless block ~-0.3 254 ~0.3 minecraft:barrier unless block ~-0.3 254 ~ minecraft:barrier unless block ~0.3 254 ~ minecraft:barrier unless block ~ 254 ~0.3 minecraft:barrier unless block ~ 254 ~-0.3 minecraft:barrier run tellraw @s[tag=Playing,gamemode=!spectator,gamemode=!creative,nbt={OnGround:1b}] {"translate":"calamity.cheated.yourself","color": "gray","italic": true}
+execute unless block ~-0.3 254 ~-0.3 minecraft:barrier unless block ~0.3 254 ~-0.3 minecraft:barrier unless block ~0.3 254 ~0.3 minecraft:barrier unless block ~-0.3 254 ~0.3 minecraft:barrier unless block ~-0.3 254 ~ minecraft:barrier unless block ~0.3 254 ~ minecraft:barrier unless block ~ 254 ~0.3 minecraft:barrier unless block ~ 254 ~-0.3 minecraft:barrier run kill @s[tag=Playing,gamemode=!spectator,gamemode=!creative,nbt={OnGround:1b}]


### PR DESCRIPTION
Region defined by y=254 barrier data layer. Moves the building protection barrier data layer to y=250. 

As a summary of what happens now...
| barrier at: | y=254 | y=255 | action |
--- | --- | --- | ---
| | no | yes | nothing; player in bounds |
| | yes | no | player is warned that they are out of bounds, title, effects |
| | no | no | player is warned and will die if on ground |
| | yes | yes | special case that will warn the players when above y=arena_height instead of killing them |

I justify these changes because I think there is merit it making the soft region an optional use, and keeping it independent from the build protection.